### PR TITLE
Selectable dither algorithms with hue-aware default

### DIFF
--- a/webserver/templates/index.html
+++ b/webserver/templates/index.html
@@ -58,6 +58,19 @@
 
   .toast { position: fixed; bottom: 20px; right: 20px; background: #333; color: #fff; padding: 10px 20px; border-radius: 6px; font-size: 0.9em; z-index: 1000; opacity: 0; transition: opacity 0.3s; }
   .toast.show { opacity: 1; }
+
+  /* Help icon + popover */
+  .help-icon { width: 22px; height: 22px; border-radius: 50%; border: 1px solid #ccc; background: #fff; color: #555; font-size: 0.85em; font-weight: 700; cursor: pointer; padding: 0; line-height: 1; display: inline-flex; align-items: center; justify-content: center; }
+  .help-icon:hover { background: #f0f0f0; border-color: #999; color: #333; }
+  .help-icon[aria-expanded="true"] { background: #2563eb; border-color: #2563eb; color: #fff; }
+  .help-popover { position: absolute; z-index: 100; background: #fff; border: 1px solid #ddd; border-radius: 8px; padding: 14px 16px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); max-width: 480px; font-size: 0.88em; line-height: 1.45; margin-top: 6px; }
+  .help-popover[hidden] { display: none; }
+  .help-popover h3 { font-size: 0.95em; margin-bottom: 8px; color: #333; }
+  .help-popover p { margin-bottom: 8px; color: #444; }
+  .help-popover p:last-child { margin-bottom: 0; }
+  .help-popover strong { color: #1d4ed8; }
+  .help-popover em { color: #666; font-style: italic; }
+  .help-popover-note { padding-top: 8px; border-top: 1px solid #eee; color: #666 !important; font-size: 0.92em; }
 </style>
 </head>
 <body>
@@ -119,6 +132,23 @@
       <option value="portrait">Portrait</option>
     </select>
     <span class="info">changing orientation re-converts all images</span>
+  </div>
+
+  <div class="config-row">
+    <label>Dither algorithm:</label>
+    <select id="dither-algorithm">
+      <option value="atkinson_hue_aware">Atkinson + hue-aware (warmer skin)</option>
+      <option value="atkinson">Atkinson (softer)</option>
+      <option value="floyd_steinberg">Floyd–Steinberg (classic)</option>
+    </select>
+    <button type="button" class="help-icon" id="dither-help-btn" aria-label="Dither algorithm help" aria-expanded="false">?</button>
+    <div id="dither-help-popover" class="help-popover" role="dialog" aria-label="Dither algorithm explanation" hidden>
+      <h3>Dither algorithms</h3>
+      <p><strong>Floyd–Steinberg (classic)</strong> — Original error-diffusion algorithm. Distributes the full quantization error to 4 neighboring pixels. Highest contrast, but warm skin tones can pick up visible blue speckles.</p>
+      <p><strong>Atkinson (softer)</strong> — Distributes only 6/8 of the error across 6 neighbors. Smoother gradients and less color bleed, but slightly lower maximum contrast.</p>
+      <p><strong>Atkinson + hue-aware</strong> — Atkinson diffusion plus a palette-selection rule that forbids large hue jumps (e.g. picking Blue for a warm pixel). Best for photos of people. <em>Default.</em></p>
+      <p class="help-popover-note">Switching triggers re-conversion of every image for the new algorithm — can take several seconds per image. Cached renders for the other algorithms are preserved, so switching back is instant.</p>
+    </div>
   </div>
 
   <div class="config-row">
@@ -219,6 +249,7 @@ async function saveConfig() {
     refresh_image_at_time: refreshTimes,
     poll_interval_seconds: parseInt(document.getElementById('poll-interval').value) || 10,
     orientation: document.getElementById('orientation').value,
+    dither_algorithm: document.getElementById('dither-algorithm').value,
   };
   try {
     const resp = await fetch('/hokku/api/config', {
@@ -330,6 +361,7 @@ async function refreshStatus() {
     renderRefreshTimes();
     document.getElementById('poll-interval').value = cfg.poll_interval_seconds || 10;
     document.getElementById('orientation').value = cfg.orientation || 'landscape';
+    document.getElementById('dither-algorithm').value = cfg.dither_algorithm || 'atkinson_hue_aware';
     document.getElementById('server-address').textContent = `${location.hostname}:${cfg.port}`;
     document.getElementById('server-time').textContent = data.server_time ? `(${data.server_time})` : '';
 
@@ -367,6 +399,32 @@ async function refreshStatus() {
     console.error('Status refresh failed:', e);
   }
 }
+
+// Dither help popover toggle (click icon to open, Esc or click-outside to close)
+(function() {
+  const btn = document.getElementById('dither-help-btn');
+  const pop = document.getElementById('dither-help-popover');
+  if (!btn || !pop) return;
+
+  function open() {
+    pop.hidden = false;
+    btn.setAttribute('aria-expanded', 'true');
+  }
+  function close() {
+    pop.hidden = true;
+    btn.setAttribute('aria-expanded', 'false');
+  }
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    pop.hidden ? open() : close();
+  });
+  document.addEventListener('click', (e) => {
+    if (!pop.hidden && !pop.contains(e.target) && e.target !== btn) close();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && !pop.hidden) close();
+  });
+})();
 
 // Initial load + auto-refresh every 5 seconds
 refreshStatus();

--- a/webserver/tests/test_webserver.py
+++ b/webserver/tests/test_webserver.py
@@ -420,5 +420,31 @@ class TestOrientation:
         with patch.object(webserver, "_config", {**webserver.DEFAULT_CONFIG, "orientation": "portrait"}):
             key_p = webserver._cache_key(path, content_hash)
         assert key_l != key_p, "Cache keys must differ between orientations"
-        assert key_l.endswith("_l")
-        assert key_p.endswith("_p")
+        # Orientation letter is embedded in the key (landscape = "l", portrait = "p")
+        assert "_l_" in key_l
+        assert "_p_" in key_p
+
+    def test_cache_key_differs_by_dither_algorithm(self):
+        """Cache keys must differ per algorithm so switching preserves prior renders."""
+        path = Path("/images/test.jpg")
+        content_hash = "abcdef123456"
+        keys = {}
+        for algo in webserver.VALID_DITHER_ALGORITHMS:
+            with patch.object(webserver, "_config", {**webserver.DEFAULT_CONFIG, "dither_algorithm": algo}):
+                keys[algo] = webserver._cache_key(path, content_hash)
+        # All three must be distinct
+        assert len(set(keys.values())) == len(keys), f"Cache keys collided: {keys}"
+        # Algorithm name must appear in each key
+        for algo, key in keys.items():
+            assert algo in key, f"Algorithm {algo} missing from cache key {key}"
+
+    def test_cache_key_algorithm_override(self):
+        """_cache_key must accept an explicit algorithm parameter that overrides _config."""
+        path = Path("/images/test.jpg")
+        content_hash = "abcdef123456"
+        with patch.object(webserver, "_config", {**webserver.DEFAULT_CONFIG, "dither_algorithm": "floyd_steinberg"}):
+            key_active = webserver._cache_key(path, content_hash)
+            key_other = webserver._cache_key(path, content_hash, algorithm="atkinson")
+        assert "floyd_steinberg" in key_active
+        assert "atkinson" in key_other
+        assert key_active != key_other

--- a/webserver/webserver.py
+++ b/webserver/webserver.py
@@ -69,6 +69,8 @@ IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".webp", ".gif", "
 
 # ── Configuration ──────────────────────────────────────────────────
 
+VALID_DITHER_ALGORITHMS = ("floyd_steinberg", "atkinson", "atkinson_hue_aware")
+
 DEFAULT_CONFIG = {
     "timezone": "America/Chicago",
     "refresh_image_at_time": ["0600", "1200", "1800"],
@@ -77,6 +79,7 @@ DEFAULT_CONFIG = {
     "port": 8080,
     "poll_interval_seconds": 10,
     "orientation": "landscape",
+    "dither_algorithm": "atkinson_hue_aware",
 }
 
 _config_file_path = None  # set during load, used for saving
@@ -114,7 +117,7 @@ def _save_config(config):
     """Save config to the file it was loaded from (or ./config.json)."""
     path = _config_file_path or Path("./config.json")
     # Only save user-facing config keys
-    save_keys = ["timezone", "refresh_image_at_time", "upload_dir", "cache_dir", "port", "poll_interval_seconds", "orientation"]
+    save_keys = ["timezone", "refresh_image_at_time", "upload_dir", "cache_dir", "port", "poll_interval_seconds", "orientation", "dither_algorithm"]
     save_data = {k: config[k] for k in save_keys if k in config}
     with open(path, "w") as f:
         json.dump(save_data, f, indent=2)
@@ -275,9 +278,11 @@ def _hash_file(img_path):
             h.update(chunk)
     return h.hexdigest()
 
-def _cache_key(img_path, content_hash):
+def _cache_key(img_path, content_hash, algorithm=None):
     orientation = _config.get("orientation", "landscape")
-    return f"{img_path.stem}_{content_hash[:12]}_{orientation[0]}"
+    if algorithm is None:
+        algorithm = _config.get("dither_algorithm", "atkinson_hue_aware")
+    return f"{img_path.stem}_{content_hash[:12]}_{orientation[0]}_{algorithm}"
 
 def _load_from_cache(cache_dir, img_path, content_hash):
     key = _cache_key(img_path, content_hash)
@@ -474,7 +479,7 @@ def _list_images():
             if f.suffix.lower() in IMAGE_EXTENSIONS and f.is_file()]
 
 
-def _prepare_canvas(img):
+def _prepare_canvas(img, color_enhance=1.2):
     """Scale image to fit display, enhance for e-ink, produce 1200x1600 native buffer.
 
     In landscape mode: composites on 1600x1200 canvas, then rotates -90° to 1200x1600.
@@ -482,6 +487,11 @@ def _prepare_canvas(img):
 
     Returns (canvas, padding_mask) where padding_mask is a boolean numpy array
     (True = padding pixel, should be forced to white after dithering).
+
+    color_enhance is the PIL ImageEnhance.Color factor. Hue-aware dithering
+    benefits from a lower saturation boost (~1.05) because it can reproduce warm
+    mid-tones without residual error; classic FS needs the full 1.2 to compensate
+    for the dithering's tendency to mute color.
     """
     from PIL import ImageEnhance, ImageOps
     orientation = _config.get("orientation", "landscape")
@@ -511,7 +521,7 @@ def _prepare_canvas(img):
     canvas = ImageEnhance.Brightness(canvas).enhance(1.0)
     canvas = ImageEnhance.Contrast(canvas).enhance(1.1)
     canvas = ImageEnhance.Sharpness(canvas).enhance(1.3)
-    canvas = ImageEnhance.Color(canvas).enhance(1.2)
+    canvas = ImageEnhance.Color(canvas).enhance(color_enhance)
 
     if not portrait:
         # Landscape: rotate -90° CW to get 1200x1600 native format
@@ -522,6 +532,7 @@ def _prepare_canvas(img):
 
 
 def _build_rgb_lut():
+    """Nearest-palette LUT by Lab-Euclidean distance (classic)."""
     steps = 32
     scale = 256 / steps
     r_vals = np.arange(steps) * scale + scale / 2
@@ -534,17 +545,66 @@ def _build_rgb_lut():
     lut = np.argmin(dists, axis=1).astype(np.uint8).reshape(steps, steps, steps)
     return lut, scale
 
-_RGB_LUT, _LUT_SCALE = _build_rgb_lut()
+
+def _build_rgb_lut_hue_aware(hue_cutoff_deg=95.0, neutral_chroma=8.0):
+    """Nearest-palette LUT that forbids palette picks whose hue differs by more
+    than hue_cutoff_deg from the source pixel. Neutrals (palette or pixel with
+    chroma < neutral_chroma) are always allowed — black/white stay candidates
+    for every pixel.
+
+    Fixes the common failure mode where error diffusion overshoots Red for warm
+    skin tones and cascades into Blue picks on neighboring pixels.
+    """
+    steps = 32
+    scale = 256 / steps
+    r_vals = np.arange(steps) * scale + scale / 2
+    rr, gg, bb = np.meshgrid(r_vals, r_vals, r_vals, indexing='ij')
+    rgb_grid = np.stack([rr, gg, bb], axis=-1).reshape(-1, 3)
+    lab_grid = _rgb_to_lab(rgb_grid)
+
+    pal_a = PALETTE_LAB[:, 1]
+    pal_b = PALETTE_LAB[:, 2]
+    pal_chroma = np.sqrt(pal_a ** 2 + pal_b ** 2)
+    pal_hue = np.arctan2(pal_b, pal_a)
+    neutral_pal = pal_chroma < neutral_chroma
+
+    pix_a = lab_grid[:, 1]
+    pix_b = lab_grid[:, 2]
+    pix_chroma = np.sqrt(pix_a ** 2 + pix_b ** 2)
+    pix_hue = np.arctan2(pix_b, pix_a)
+
+    dh = pix_hue[:, None] - pal_hue[None, :]
+    dh = np.arctan2(np.sin(dh), np.cos(dh))
+    dh_deg = np.abs(np.degrees(dh))
+
+    forbidden = (
+        (pix_chroma[:, None] > neutral_chroma) &
+        (~neutral_pal[None, :]) &
+        (dh_deg > hue_cutoff_deg)
+    )
+
+    dists = np.sum((lab_grid[:, None, :] - PALETTE_LAB[None, :, :]) ** 2, axis=2)
+    dists = np.where(forbidden, np.inf, dists)
+    lut = np.argmin(dists, axis=1).astype(np.uint8).reshape(steps, steps, steps)
+    return lut, scale
 
 
-def _floyd_steinberg_dither(canvas):
+_RGB_LUT_EUCLID, _LUT_SCALE = _build_rgb_lut()
+_RGB_LUT_HUE_AWARE, _ = _build_rgb_lut_hue_aware()
+
+
+def _floyd_steinberg_dither(canvas, lut=None, lut_scale=None):
+    """Floyd–Steinberg error diffusion. Full error distributed to 4 neighbors
+    (7/16 right, 3/16 down-left, 5/16 down, 1/16 down-right)."""
+    if lut is None:
+        lut = _RGB_LUT_EUCLID
+    if lut_scale is None:
+        lut_scale = _LUT_SCALE
     pixels = np.array(canvas, dtype=np.float32)
     h, w, _ = pixels.shape
     result_idx = np.zeros((h, w), dtype=np.uint8)
     pal_rgb = PALETTE_MEASURED_RGB
-    lut = _RGB_LUT
     lut_max = lut.shape[0] - 1
-    lut_scale = _LUT_SCALE
 
     for y in range(h):
         for x in range(w):
@@ -580,6 +640,59 @@ def _floyd_steinberg_dither(canvas):
     return result_idx
 
 
+def _atkinson_dither(canvas, lut=None, lut_scale=None):
+    """Atkinson dither. Distributes only 6/8 of the quantization error, 1/8 each
+    into 6 neighbors: (+1,0), (+2,0), (-1,+1), (0,+1), (+1,+1), (0,+2). Softer
+    gradients, less hue-shift cascade, slightly lower max contrast than FS."""
+    if lut is None:
+        lut = _RGB_LUT_EUCLID
+    if lut_scale is None:
+        lut_scale = _LUT_SCALE
+    pixels = np.array(canvas, dtype=np.float32)
+    h, w, _ = pixels.shape
+    result_idx = np.zeros((h, w), dtype=np.uint8)
+    pal_rgb = PALETTE_MEASURED_RGB
+    lut_max = lut.shape[0] - 1
+    # (dx, dy)
+    offsets = ((1, 0), (2, 0), (-1, 1), (0, 1), (1, 1), (0, 2))
+    w_coef = 1.0 / 8.0
+
+    for y in range(h):
+        for x in range(w):
+            r = min(max(pixels[y, x, 0], 0.0), 255.0)
+            g = min(max(pixels[y, x, 1], 0.0), 255.0)
+            b = min(max(pixels[y, x, 2], 0.0), 255.0)
+            ri = min(int(r / lut_scale), lut_max)
+            gi = min(int(g / lut_scale), lut_max)
+            bi = min(int(b / lut_scale), lut_max)
+            idx = int(lut[ri, gi, bi])
+            result_idx[y, x] = idx
+            er = (r - pal_rgb[idx, 0]) * w_coef
+            eg = (g - pal_rgb[idx, 1]) * w_coef
+            eb = (b - pal_rgb[idx, 2]) * w_coef
+            for dx, dy in offsets:
+                nx, ny = x + dx, y + dy
+                if 0 <= nx < w and 0 <= ny < h:
+                    pixels[ny, nx, 0] += er
+                    pixels[ny, nx, 1] += eg
+                    pixels[ny, nx, 2] += eb
+        if y % 200 == 0:
+            print(f"  Dithering: {y}/{h}")
+    return result_idx
+
+
+def _dither_for_algorithm(algorithm):
+    """Return (dither_fn, lut, color_enhance) for the configured algorithm."""
+    if algorithm == "floyd_steinberg":
+        return _floyd_steinberg_dither, _RGB_LUT_EUCLID, 1.2
+    if algorithm == "atkinson":
+        return _atkinson_dither, _RGB_LUT_EUCLID, 1.2
+    if algorithm == "atkinson_hue_aware":
+        return _atkinson_dither, _RGB_LUT_HUE_AWARE, 1.05
+    # Fallback matches new default so unknown config values don't hard-fail.
+    return _atkinson_dither, _RGB_LUT_HUE_AWARE, 1.05
+
+
 def _convert_image(img_path):
     print(f"Converting: {img_path.name}")
     t0 = time.time()
@@ -591,10 +704,15 @@ def _convert_image(img_path):
     img = ImageOps.exif_transpose(img)
     img = img.convert("RGB")
     print(f"  {img_path.name}: {img.size[0]}x{img.size[1]}")
-    canvas, padding_mask = _prepare_canvas(img)
+
+    algorithm = _config.get("dither_algorithm", "atkinson_hue_aware")
+    dither_fn, lut, color_enhance = _dither_for_algorithm(algorithm)
+    print(f"  {img_path.name}: algorithm={algorithm}")
+
+    canvas, padding_mask = _prepare_canvas(img, color_enhance=color_enhance)
     canvas_array = _compress_dynamic_range(np.array(canvas, dtype=np.float32))
     canvas = Image.fromarray(canvas_array.astype(np.uint8))
-    result_idx = _floyd_steinberg_dither(canvas)
+    result_idx = dither_fn(canvas, lut, _LUT_SCALE)
 
     # Force padding areas to pure white (palette index 1) — without this,
     # the enhancement + dithering pipeline turns pure white into a slightly
@@ -705,7 +823,10 @@ def _sync_pool_inner():
     with _lock:
         valid_cache_keys = set()
         for key, entry in _pool.items():
-            valid_cache_keys.add(_cache_key(Path(key), entry["hash"]))
+            # Keep cached renders for every algorithm, not just the active one,
+            # so toggling the dither dropdown is instant on a re-visit.
+            for algo in VALID_DITHER_ALGORITHMS:
+                valid_cache_keys.add(_cache_key(Path(key), entry["hash"], algorithm=algo))
     _purge_stale_cache(cache_dir, valid_cache_keys)
 
 
@@ -825,6 +946,7 @@ def api_status():
                 "port": _config["port"],
                 "poll_interval_seconds": _config.get("poll_interval_seconds", 10),
                 "orientation": _config.get("orientation", "landscape"),
+                "dither_algorithm": _config.get("dither_algorithm", "atkinson_hue_aware"),
                 "upload_dir": str(_get_upload_dir()),
                 "cache_dir": str(_get_cache_dir()),
             },
@@ -954,6 +1076,16 @@ def api_config():
             _config["orientation"] = val
             changed = True
 
+    algorithm_changed = False
+    if "dither_algorithm" in data:
+        val = data["dither_algorithm"]
+        if val not in VALID_DITHER_ALGORITHMS:
+            return jsonify({"error": f"Unknown dither_algorithm: {val}"}), 400
+        if _config.get("dither_algorithm", "atkinson_hue_aware") != val:
+            algorithm_changed = True
+        _config["dither_algorithm"] = val
+        changed = True
+
     if changed:
         _save_config(_config)
 
@@ -963,12 +1095,21 @@ def api_config():
         with _lock:
             _pool.clear()
         threading.Thread(target=_sync_pool, daemon=True).start()
+    elif algorithm_changed:
+        # Algorithm change: cache key changes so pool entries won't find matching
+        # renders. Drop the pool to force _sync_pool to re-run _convert_and_store,
+        # which hits cache for algorithms we've rendered before (instant) and
+        # falls through to _convert_image for new ones.
+        with _lock:
+            _pool.clear()
+        threading.Thread(target=_sync_pool, daemon=True).start()
 
     return jsonify({"status": "ok", "config": {
         "timezone": _config["timezone"],
         "refresh_image_at_time": _config["refresh_image_at_time"],
         "poll_interval_seconds": _config.get("poll_interval_seconds", 10),
         "orientation": _config.get("orientation", "landscape"),
+        "dither_algorithm": _config.get("dither_algorithm", "atkinson_hue_aware"),
     }})
 
 


### PR DESCRIPTION
## Summary

- Adds a **Dither algorithm** dropdown to the web UI with three options: Floyd–Steinberg (classic), Atkinson (softer), and **Atkinson + hue-aware (new default)**.
- The hue-aware variant forbids palette picks whose hue differs by >95° from the source pixel, which removes the blue-tint artifact on warm skin tones (caused by FS error-diffusion overshoot cascading Red → Blue neighbors).
- Cache keys now include the algorithm so cached renders for all variants coexist — switching back to a previously-rendered algorithm is instant.
- New (?) help icon explains the tradeoffs inline and warns that switching re-converts every image.

## Why

On the Spectra 6 palette, FS error-diffusion produces a visible blue cast on lips and skin. The palette has no pink/peach primary, so accumulated error eventually forces a Red pick ([135,19,0], very dark), and the large residual pushes neighbors into Blue territory. Forbidding hue-distant palette picks breaks that cascade. Atkinson's 6/8 damping further reduces overshoot.

## Implementation notes

- \`_build_rgb_lut_hue_aware()\` — precomputed 32³ LUT with forbidden hue-distant picks (neutrals always allowed).
- \`_atkinson_dither()\` — parallels existing \`_floyd_steinberg_dither\`, distributes 1/8 of error into 6 neighbors.
- \`_dither_for_algorithm()\` dispatches \`(fn, lut, color_enhance)\` — hue-aware uses 1.05 saturation (vs 1.2) since it reproduces warm mid-tones directly.
- Cache key is now \`{stem}_{hash}_{orient}_{algorithm}\`. \`_sync_pool_inner\` purge preserves entries for all valid algorithms.
- \`api_config\` validates the algorithm (400 on unknown), drops \`_pool\`, and triggers a background \`_sync_pool\` on change.

## Test plan

- [x] \`pytest webserver/tests/\` — 46 passed, including new cache-key-per-algorithm tests
- [ ] Manual UI test: confirm dropdown + (?) popover (click / Esc / click-outside dismiss) and that saving triggers visible re-conversion
- [ ] End-to-end: upload a portrait, verify hue-aware lacks blue speckles on skin; switch to FS, confirm re-conversion; switch back, confirm it's instant (cache hit)
- [ ] Confirm existing configs without \`dither_algorithm\` boot fine and pick up the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)