### PR TITLE
Add fs_hue_aware variant as new default dither algorithm

### DIFF
--- a/webserver/templates/index.html
+++ b/webserver/templates/index.html
@@ -137,16 +137,18 @@
   <div class="config-row">
     <label>Dither algorithm:</label>
     <select id="dither-algorithm">
-      <option value="atkinson_hue_aware">Atkinson + hue-aware (warmer skin)</option>
-      <option value="atkinson">Atkinson (softer)</option>
+      <option value="fs_hue_aware">Floyd–Steinberg + hue-aware (best for photos)</option>
+      <option value="atkinson_hue_aware">Atkinson + hue-aware (softer texture)</option>
+      <option value="atkinson">Atkinson (no hue correction)</option>
       <option value="floyd_steinberg">Floyd–Steinberg (classic)</option>
     </select>
     <button type="button" class="help-icon" id="dither-help-btn" aria-label="Dither algorithm help" aria-expanded="false">?</button>
     <div id="dither-help-popover" class="help-popover" role="dialog" aria-label="Dither algorithm explanation" hidden>
       <h3>Dither algorithms</h3>
-      <p><strong>Floyd–Steinberg (classic)</strong> — Original error-diffusion algorithm. Distributes the full quantization error to 4 neighboring pixels. Highest contrast, but warm skin tones can pick up visible blue speckles.</p>
-      <p><strong>Atkinson (softer)</strong> — Distributes only 6/8 of the error across 6 neighbors. Smoother gradients and less color bleed, but slightly lower maximum contrast.</p>
-      <p><strong>Atkinson + hue-aware</strong> — Atkinson diffusion plus a palette-selection rule that forbids large hue jumps (e.g. picking Blue for a warm pixel). Best for photos of people. <em>Default.</em></p>
+      <p><strong>Floyd–Steinberg + hue-aware</strong> — FS error diffusion combined with a palette-selection rule that forbids large hue jumps (so warm skin tones don't pick up blue speckles) and chroma-preserving dynamic-range compression (keeps small saturated features like lips and tongues from washing out). Best overall for photos. <em>Default.</em> B&amp;W inputs are auto-detected and rendered with a neutral preset to avoid pink cast.</p>
+      <p><strong>Atkinson + hue-aware</strong> — Same hue-aware palette rule, but with Atkinson's 6/8 error diffusion: softer noise texture, at the cost of slightly muted small saturated features.</p>
+      <p><strong>Atkinson (no hue correction)</strong> — Plain Atkinson against Lab-nearest palette matching. Softer, but warm tones may drift blue.</p>
+      <p><strong>Floyd–Steinberg (classic)</strong> — Full-strength error diffusion, Lab-nearest palette matching. Highest contrast but can show blue speckles on skin.</p>
       <p class="help-popover-note">Switching triggers re-conversion of every image for the new algorithm — can take several seconds per image. Cached renders for the other algorithms are preserved, so switching back is instant.</p>
     </div>
   </div>
@@ -361,7 +363,7 @@ async function refreshStatus() {
     renderRefreshTimes();
     document.getElementById('poll-interval').value = cfg.poll_interval_seconds || 10;
     document.getElementById('orientation').value = cfg.orientation || 'landscape';
-    document.getElementById('dither-algorithm').value = cfg.dither_algorithm || 'atkinson_hue_aware';
+    document.getElementById('dither-algorithm').value = cfg.dither_algorithm || 'fs_hue_aware';
     document.getElementById('server-address').textContent = `${location.hostname}:${cfg.port}`;
     document.getElementById('server-time').textContent = data.server_time ? `(${data.server_time})` : '';
 

--- a/webserver/tests/test_webserver.py
+++ b/webserver/tests/test_webserver.py
@@ -448,3 +448,50 @@ class TestOrientation:
         assert "floyd_steinberg" in key_active
         assert "atkinson" in key_other
         assert key_active != key_other
+
+    def test_default_is_fs_hue_aware(self):
+        """fs_hue_aware is the new default algorithm."""
+        assert webserver.DEFAULT_CONFIG["dither_algorithm"] == "fs_hue_aware"
+        assert "fs_hue_aware" in webserver.VALID_DITHER_ALGORITHMS
+
+    def test_dither_for_algorithm_returns_four_tuple(self):
+        """_dither_for_algorithm now returns (fn, lut, color_enhance, scale_chroma)."""
+        for algo in webserver.VALID_DITHER_ALGORITHMS:
+            result = webserver._dither_for_algorithm(algo)
+            assert len(result) == 4, f"{algo}: expected 4-tuple, got {len(result)}"
+            fn, lut, enhance, scale_chroma = result
+            assert callable(fn)
+            assert isinstance(enhance, float)
+            assert isinstance(scale_chroma, bool)
+        # Only fs_hue_aware uses chroma scaling
+        _, _, _, sc_fs = webserver._dither_for_algorithm("fs_hue_aware")
+        _, _, _, sc_ahu = webserver._dither_for_algorithm("atkinson_hue_aware")
+        assert sc_fs is True
+        assert sc_ahu is False
+
+    def test_is_near_grayscale_detects_bw(self):
+        """B&W source should be flagged; colorful source should not."""
+        # Grayscale: R=G=B across a range of values
+        bw = Image.new("RGB", (400, 300))
+        pixels = bw.load()
+        for y in range(300):
+            for x in range(400):
+                v = (x * 255) // 400
+                pixels[x, y] = (v, v, v)
+        assert webserver._is_near_grayscale(bw) is True
+
+        # Saturated red + blue patches
+        color = Image.new("RGB", (400, 300), (200, 40, 40))
+        assert webserver._is_near_grayscale(color) is False
+
+    def test_compress_dynamic_range_scale_chroma_flag(self):
+        """scale_chroma=True should reduce output chroma for saturated input."""
+        img = np.full((8, 8, 3), [220, 40, 40], dtype=np.float32)  # saturated red
+        out_lonly = webserver._compress_dynamic_range(img, scale_chroma=False)
+        out_vivid = webserver._compress_dynamic_range(img, scale_chroma=True)
+        # vividness path scales chroma down in sync with L, so a/b in Lab are smaller
+        lab_lonly = webserver._rgb_to_lab(out_lonly)
+        lab_vivid = webserver._rgb_to_lab(out_vivid)
+        chroma_lonly = np.sqrt(lab_lonly[..., 1] ** 2 + lab_lonly[..., 2] ** 2).mean()
+        chroma_vivid = np.sqrt(lab_vivid[..., 1] ** 2 + lab_vivid[..., 2] ** 2).mean()
+        assert chroma_vivid < chroma_lonly, f"vivid={chroma_vivid:.1f} should be < lonly={chroma_lonly:.1f}"

--- a/webserver/webserver.py
+++ b/webserver/webserver.py
@@ -69,7 +69,7 @@ IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".webp", ".gif", "
 
 # ── Configuration ──────────────────────────────────────────────────
 
-VALID_DITHER_ALGORITHMS = ("floyd_steinberg", "atkinson", "atkinson_hue_aware")
+VALID_DITHER_ALGORITHMS = ("floyd_steinberg", "atkinson", "atkinson_hue_aware", "fs_hue_aware")
 
 DEFAULT_CONFIG = {
     "timezone": "America/Chicago",
@@ -79,7 +79,7 @@ DEFAULT_CONFIG = {
     "port": 8080,
     "poll_interval_seconds": 10,
     "orientation": "landscape",
-    "dither_algorithm": "atkinson_hue_aware",
+    "dither_algorithm": "fs_hue_aware",
 }
 
 _config_file_path = None  # set during load, used for saving
@@ -238,13 +238,24 @@ _DISPLAY_WHITE_L = float(_rgb_to_lab(PALETTE_MEASURED_RGB[1:2])[0, 0])
 # dithering algorithm doesn't try to reproduce brightness levels the panel
 # can't show. Based on esp32-photoframe's preprocessImage approach.
 
-def _compress_dynamic_range(img_array):
-    """Compress image luminance from full [0,100] L* to display's actual range."""
+def _compress_dynamic_range(img_array, scale_chroma=False):
+    """Compress image luminance from full [0,100] L* to display's actual range.
+
+    When scale_chroma is True ("vividness-preserved" mode), a* and b* are scaled
+    by the same ratio used on L*. This keeps the chroma-to-lightness ratio of the
+    source intact, so saturated mid-tones don't drift out of the palette's
+    reachable gamut after L is pulled in. Required for fs_hue_aware; optional
+    for the other algorithms.
+    """
     rgb = np.asarray(img_array, dtype=np.float64)
     linear = _srgb_to_linear(rgb)
     xyz = _linear_to_xyz(linear)
     lab = _xyz_to_lab(xyz)
-    lab[..., 0] = _DISPLAY_BLACK_L + (lab[..., 0] / 100.0) * (_DISPLAY_WHITE_L - _DISPLAY_BLACK_L)
+    L_ratio = (_DISPLAY_WHITE_L - _DISPLAY_BLACK_L) / 100.0
+    lab[..., 0] = _DISPLAY_BLACK_L + lab[..., 0] * L_ratio
+    if scale_chroma:
+        lab[..., 1] *= L_ratio
+        lab[..., 2] *= L_ratio
     ref = np.array([0.95047, 1.00000, 1.08883])
     L, a, b = lab[..., 0], lab[..., 1], lab[..., 2]
     fy = (L + 16) / 116.0
@@ -281,7 +292,7 @@ def _hash_file(img_path):
 def _cache_key(img_path, content_hash, algorithm=None):
     orientation = _config.get("orientation", "landscape")
     if algorithm is None:
-        algorithm = _config.get("dither_algorithm", "atkinson_hue_aware")
+        algorithm = _config.get("dither_algorithm", "fs_hue_aware")
     return f"{img_path.stem}_{content_hash[:12]}_{orientation[0]}_{algorithm}"
 
 def _load_from_cache(cache_dir, img_path, content_hash):
@@ -682,15 +693,45 @@ def _atkinson_dither(canvas, lut=None, lut_scale=None):
 
 
 def _dither_for_algorithm(algorithm):
-    """Return (dither_fn, lut, color_enhance) for the configured algorithm."""
+    """Return (dither_fn, lut, color_enhance, scale_chroma) for the algorithm.
+
+    scale_chroma enables vividness-preserved dynamic-range compression (scales
+    a*/b* by the same ratio as L*). fs_hue_aware relies on this to keep
+    saturated mid-tones reachable after L compression; older algorithms keep
+    the legacy L-only behavior.
+    """
     if algorithm == "floyd_steinberg":
-        return _floyd_steinberg_dither, _RGB_LUT_EUCLID, 1.2
+        return _floyd_steinberg_dither, _RGB_LUT_EUCLID, 1.2, False
     if algorithm == "atkinson":
-        return _atkinson_dither, _RGB_LUT_EUCLID, 1.2
+        return _atkinson_dither, _RGB_LUT_EUCLID, 1.2, False
     if algorithm == "atkinson_hue_aware":
-        return _atkinson_dither, _RGB_LUT_HUE_AWARE, 1.05
+        return _atkinson_dither, _RGB_LUT_HUE_AWARE, 1.05, False
+    if algorithm == "fs_hue_aware":
+        return _floyd_steinberg_dither, _RGB_LUT_HUE_AWARE, 1.2, True
     # Fallback matches new default so unknown config values don't hard-fail.
-    return _atkinson_dither, _RGB_LUT_HUE_AWARE, 1.05
+    return _floyd_steinberg_dither, _RGB_LUT_HUE_AWARE, 1.2, True
+
+
+# Images whose max chroma stays below this threshold are treated as near-grayscale
+# and rendered with the conservative preset (no vividness scaling, modest enhance).
+# Without this, fs_hue_aware's chroma amplification gives B&W photos a pink cast.
+_GRAYSCALE_CHROMA_THRESHOLD = 8.0
+
+
+def _is_near_grayscale(img):
+    """Detect near-B&W source images by sampling Lab chroma.
+
+    Downsamples to 200px for speed, converts to Lab, and returns True if the
+    95th-percentile chroma is below _GRAYSCALE_CHROMA_THRESHOLD. Downsampling
+    rather than sampling avoids being fooled by a single chromatic pixel in
+    an otherwise grayscale image.
+    """
+    thumb = img.copy()
+    thumb.thumbnail((200, 200), Image.LANCZOS)
+    arr = np.asarray(thumb.convert("RGB"), dtype=np.float64)
+    lab = _xyz_to_lab(_linear_to_xyz(_srgb_to_linear(arr)))
+    chroma = np.sqrt(lab[..., 1] ** 2 + lab[..., 2] ** 2)
+    return float(np.percentile(chroma, 95)) < _GRAYSCALE_CHROMA_THRESHOLD
 
 
 def _convert_image(img_path):
@@ -705,12 +746,20 @@ def _convert_image(img_path):
     img = img.convert("RGB")
     print(f"  {img_path.name}: {img.size[0]}x{img.size[1]}")
 
-    algorithm = _config.get("dither_algorithm", "atkinson_hue_aware")
-    dither_fn, lut, color_enhance = _dither_for_algorithm(algorithm)
-    print(f"  {img_path.name}: algorithm={algorithm}")
+    algorithm = _config.get("dither_algorithm", "fs_hue_aware")
+    dither_fn, lut, color_enhance, scale_chroma = _dither_for_algorithm(algorithm)
+
+    # fs_hue_aware's 1.2 color enhance + vividness compression amplifies tiny
+    # chroma deviations in near-grayscale images into a visible color cast.
+    # Detect B&W inputs and fall back to the conservative preset.
+    if scale_chroma and _is_near_grayscale(img):
+        print(f"  {img_path.name}: B&W detected, using conservative preset")
+        color_enhance, scale_chroma = 1.05, False
+
+    print(f"  {img_path.name}: algorithm={algorithm} enhance={color_enhance} scale_chroma={scale_chroma}")
 
     canvas, padding_mask = _prepare_canvas(img, color_enhance=color_enhance)
-    canvas_array = _compress_dynamic_range(np.array(canvas, dtype=np.float32))
+    canvas_array = _compress_dynamic_range(np.array(canvas, dtype=np.float32), scale_chroma=scale_chroma)
     canvas = Image.fromarray(canvas_array.astype(np.uint8))
     result_idx = dither_fn(canvas, lut, _LUT_SCALE)
 
@@ -946,7 +995,7 @@ def api_status():
                 "port": _config["port"],
                 "poll_interval_seconds": _config.get("poll_interval_seconds", 10),
                 "orientation": _config.get("orientation", "landscape"),
-                "dither_algorithm": _config.get("dither_algorithm", "atkinson_hue_aware"),
+                "dither_algorithm": _config.get("dither_algorithm", "fs_hue_aware"),
                 "upload_dir": str(_get_upload_dir()),
                 "cache_dir": str(_get_cache_dir()),
             },
@@ -1081,7 +1130,7 @@ def api_config():
         val = data["dither_algorithm"]
         if val not in VALID_DITHER_ALGORITHMS:
             return jsonify({"error": f"Unknown dither_algorithm: {val}"}), 400
-        if _config.get("dither_algorithm", "atkinson_hue_aware") != val:
+        if _config.get("dither_algorithm", "fs_hue_aware") != val:
             algorithm_changed = True
         _config["dither_algorithm"] = val
         changed = True
@@ -1109,7 +1158,7 @@ def api_config():
         "refresh_image_at_time": _config["refresh_image_at_time"],
         "poll_interval_seconds": _config.get("poll_interval_seconds", 10),
         "orientation": _config.get("orientation", "landscape"),
-        "dither_algorithm": _config.get("dither_algorithm", "atkinson_hue_aware"),
+        "dither_algorithm": _config.get("dither_algorithm", "fs_hue_aware"),
     }})
 
 


### PR DESCRIPTION
Adds Floyd-Steinberg + hue-aware palette selection + vividness-preserved dynamic-range compression as a fourth algorithm option, and makes it the new default. FS's full error cascade consolidates small saturated features (lips, tongues, logos) better than Atkinson's 6/8 damping, while hue-aware still prevents the blue-speckle problem that motivated the atkinson switch. Vividness compression scales a*/b* with L* so saturated mid-tones stay reachable by the palette after dynamic-range compression.

Auto-detects near-grayscale inputs and falls back to enhance=1.05 + L-only compression to avoid giving B&W photos a pink cast.