### PR TITLE
Add Seeed reTerminal E1004 client (13.3" Spectra 6 as a hokku screen)

### DIFF
--- a/clients/reterminal_e1004/GxEPD2_T133A01_1200x1600.cpp
+++ b/clients/reterminal_e1004/GxEPD2_T133A01_1200x1600.cpp
@@ -1,0 +1,626 @@
+// GxEPD2 driver for the T133A01 (13.3", 1200 x 1600, 7-color) dual-chip panel
+// on the Seeed reTerminal E1004.  See header for design notes.
+
+#include "GxEPD2_T133A01_1200x1600.h"
+
+#if defined(ESP32)
+#include <esp_heap_caps.h>
+#endif
+
+#define DBG Serial0
+
+// T133A01 register constants and init data (from Seeed_GFX T133A01_Defines.h)
+static const uint8_t PSR_V[]   = {0xDF, 0x69};
+static const uint8_t PWR_V[]   = {0x0F, 0x00, 0x28, 0x2C, 0x28, 0x38};
+static const uint8_t POF_V[]   = {0x00};
+static const uint8_t DRF_V[]   = {0x01};
+static const uint8_t CDI_V[]   = {0x37};
+static const uint8_t TRES_V[]  = {0x04, 0xB0, 0x03, 0x20};
+static const uint8_t AMV_V[]   = {0x01, 0x00};
+static const uint8_t CCSET_CUR[] = {0x01};
+static const uint8_t PWS_V[]  = {0x22};
+static const uint8_t DCDC_V[] = {0x44, 0x54, 0x00};
+static const uint8_t BTST_P_V[] = {0xE0, 0x20};
+static const uint8_t BTST_N_V[] = {0xE0, 0x20};
+static const uint8_t r74[] = {0x00, 0x0C, 0x0C, 0xD9, 0xDD, 0xDD, 0x15, 0x15, 0x55};
+static const uint8_t rf0[] = {0x49, 0x55, 0x13, 0x5D, 0x05, 0x10};
+static const uint8_t r60[] = {0x03, 0x03};
+static const uint8_t r86[] = {0x10};
+static const uint8_t rb6[] = {0x07};
+static const uint8_t rb7[] = {0x01};
+static const uint8_t rb0[] = {0x01};
+static const uint8_t rb1[] = {0x02};
+
+// Register addresses
+#define R00_PSR   0x00
+#define R01_PWR   0x01
+#define R02_POF   0x02
+#define R04_PON   0x04
+#define R05_BTST_N 0x05
+#define R06_BTST_P 0x06
+#define R10_DTM   0x10
+#define R12_DRF   0x12
+#define R50_CDI   0x50
+#define R61_TRES  0x61
+#define RA5_DCDC  0xA5
+#define RE0_CCSET 0xE0
+#define RE3_PWS   0xE3
+
+// GxEPD2 color encoding → T133A01 native encoding
+//
+// T133A01 native palette (Spectra 6 — Black/White/Red/Green/Blue/Yellow):
+//   0x00 = Black, 0x01 = White, 0x02 = Yellow, 0x03 = Red,
+//   0x05 = Blue,  0x06 = Green       (0x04, 0x07 unused on this panel)
+//
+// GxEPD2 color7() palette (drawing API supports 7 entries):
+//   0=Black 1=White 2=Green 3=Blue 4=Red 5=Yellow 6=Orange 7=unused
+//
+// Spectra 6 has no orange; GxEPD_ORANGE is therefore aliased to yellow
+// (closest visual match).  Application code should normally avoid
+// GxEPD_ORANGE on this board.
+static const uint8_t _native_map[8] = {
+  0x00, // 0: Black  -> 0x00
+  0x01, // 1: White  -> 0x01
+  0x06, // 2: Green  -> 0x06
+  0x05, // 3: Blue   -> 0x05
+  0x03, // 4: Red    -> 0x03
+  0x02, // 5: Yellow -> 0x02
+  0x02, // 6: Orange -> 0x02 (no native orange; alias to yellow)
+  0x01, // 7: unused -> 0x01 (white fallback)
+};
+
+GxEPD2_T133A01_1200x1600::GxEPD2_T133A01_1200x1600(
+    int16_t cs, int16_t dc, int16_t rst, int16_t busy,
+    int16_t cs1, int16_t enable)
+  : GxEPD2_EPD(cs, dc, rst, busy, LOW, 60000, WIDTH, HEIGHT, panel, hasColor,
+                hasPartialUpdate, hasFastPartialUpdate),
+    _cs1(cs1), _enable(enable), _frame_buf(nullptr), _paged(false)
+{
+}
+
+// ---- helpers ----
+
+uint8_t GxEPD2_T133A01_1200x1600::_convert_to_native(uint8_t data)
+{
+  uint8_t hi = (data >> 4) & 0x07;
+  uint8_t lo = data & 0x07;
+  return (_native_map[hi] << 4) | _native_map[lo];
+}
+
+// Send a command + data sequence to BOTH chips simultaneously.
+// CS toggling happens OUTSIDE the SPI transaction to mirror Seeed_GFX timing.
+void GxEPD2_T133A01_1200x1600::_sendCmdDataBoth(uint8_t cmd, const uint8_t* data, uint16_t len)
+{
+  digitalWrite(_cs1, LOW);                  // slave selected
+  if (_cs >= 0) digitalWrite(_cs, LOW);     // master selected
+  _pSPIx->beginTransaction(_spi_settings);
+  if (_dc >= 0) digitalWrite(_dc, LOW);
+  _pSPIx->transfer(cmd);
+  if (_dc >= 0) digitalWrite(_dc, HIGH);
+  for (uint16_t i = 0; i < len; i++) _pSPIx->transfer(data[i]);
+  _pSPIx->endTransaction();
+  if (_cs >= 0) digitalWrite(_cs, HIGH);    // master deselected
+  digitalWrite(_cs1, HIGH);                 // slave deselected
+}
+
+// Send a command + data sequence to the MASTER chip only.
+void GxEPD2_T133A01_1200x1600::_sendCmdDataCS0(uint8_t cmd, const uint8_t* data, uint16_t len)
+{
+  digitalWrite(_cs1, HIGH);                 // ensure slave NOT selected
+  if (_cs >= 0) digitalWrite(_cs, LOW);     // master selected
+  _pSPIx->beginTransaction(_spi_settings);
+  if (_dc >= 0) digitalWrite(_dc, LOW);
+  _pSPIx->transfer(cmd);
+  if (_dc >= 0) digitalWrite(_dc, HIGH);
+  for (uint16_t i = 0; i < len; i++) _pSPIx->transfer(data[i]);
+  _pSPIx->endTransaction();
+  if (_cs >= 0) digitalWrite(_cs, HIGH);    // master deselected
+}
+
+// Strict port of Seeed_GFX CHECK_BUSY() — always delay first, then poll.
+// This avoids the classic "BUSY hasn't gone low yet" race that the upstream
+// GxEPD2_EPD::_waitWhileBusy can fall into (it polls after only 1 ms).
+void GxEPD2_T133A01_1200x1600::_checkBusy(const char* tag, uint32_t timeout_ms)
+{
+  if (_busy < 0) {
+    delay(timeout_ms < 1000 ? timeout_ms : 100);
+    return;
+  }
+  unsigned long t_start = millis();
+  uint32_t polls = 0;
+  while (true) {
+    delay(10);
+    polls++;
+    if (digitalRead(_busy) == HIGH) break;     // ready
+    if (millis() - t_start > timeout_ms) {
+      if (_diag_enabled) {
+        DBG.print(F("[T133A01] BUSY timeout @ "));
+        DBG.print(tag);
+        DBG.print(F(" after "));
+        DBG.print(millis() - t_start);
+        DBG.println(F(" ms"));
+      }
+      break;
+    }
+  }
+  if (_diag_enabled) {
+    unsigned long dt = millis() - t_start;
+    DBG.print(F("[T133A01] busy["));
+    DBG.print(tag);
+    DBG.print(F("] ms="));
+    DBG.print(dt);
+    DBG.print(F(" polls="));
+    DBG.println(polls);
+  }
+}
+
+void GxEPD2_T133A01_1200x1600::_allocFrameBuffer()
+{
+  if (_frame_buf) return;
+#if defined(ESP32)
+  _frame_buf = (uint8_t*)heap_caps_malloc(FRAME_BYTES, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+#else
+  _frame_buf = (uint8_t*)malloc(FRAME_BYTES);
+#endif
+  if (!_frame_buf) {
+    DBG.println(F("[T133A01] FATAL: PSRAM alloc failed (960 KB needed)"));
+    while (true) delay(1000);
+  }
+}
+
+// Fill with GxEPD2-encoded value (0x11 = white, 0x00 = black)
+void GxEPD2_T133A01_1200x1600::_fillFrameBuffer(uint8_t value)
+{
+  _allocFrameBuffer();
+  memset(_frame_buf, value, FRAME_BYTES);
+}
+
+// ---- init ----
+
+void GxEPD2_T133A01_1200x1600::init(uint32_t serial_diag_bitrate)
+{
+  init(serial_diag_bitrate, true, 10, false);
+}
+
+void GxEPD2_T133A01_1200x1600::init(uint32_t serial_diag_bitrate,
+                                      bool initial, uint16_t reset_duration,
+                                      bool pulldown_rst_mode)
+{
+  _initial_write = initial;
+  _initial_refresh = initial;
+  _pulldown_rst_mode = pulldown_rst_mode;
+  _power_is_on = false;
+  _using_partial_mode = false;
+  _hibernating = false;
+  _init_display_done = false;
+  _reset_duration = reset_duration;
+
+  // Force diagnostics on while bringing the panel up.  Comment this out
+  // once everything works to silence per-refresh log lines.
+  _diag_enabled = true;
+  if (serial_diag_bitrate > 0) {
+    _diag_enabled = true;
+  }
+
+  // Pin setup (from T133A01_Init.h)
+  if (_cs >= 0) { pinMode(_cs, OUTPUT); digitalWrite(_cs, HIGH); }
+  if (_dc >= 0) { pinMode(_dc, OUTPUT); digitalWrite(_dc, HIGH); }
+  if (_rst >= 0) { pinMode(_rst, OUTPUT); digitalWrite(_rst, HIGH); }
+  if (_busy >= 0) { pinMode(_busy, INPUT); }
+  pinMode(_cs1, OUTPUT); digitalWrite(_cs1, HIGH);
+  if (_enable >= 0) { pinMode(_enable, OUTPUT); digitalWrite(_enable, HIGH); }
+
+  _allocFrameBuffer();
+  _fillFrameBuffer(0x11); // white in GxEPD2 encoding
+
+  _InitDisplay();
+
+  if (_diag_enabled) {
+    DBG.println(F("[T133A01] init done: 1200x1600 7-color, dual-chip"));
+  }
+}
+
+void GxEPD2_T133A01_1200x1600::_InitDisplay()
+{
+  // Hardware reset
+  if (_rst >= 0) {
+    digitalWrite(_rst, LOW); delay(20);
+    digitalWrite(_rst, HIGH); delay(20);
+  }
+  _waitWhileBusy("reset", 5000);
+
+  // 0x74: undocumented config → main CS only
+  _sendCmdDataCS0(0x74, r74, sizeof(r74));
+  delay(10);
+
+  // 0xF0: undocumented config → both chips
+  _sendCmdDataBoth(0xF0, rf0, sizeof(rf0));
+  delay(10);
+
+  // PSR (Panel Setting) → both
+  _sendCmdDataBoth(R00_PSR, PSR_V, sizeof(PSR_V));
+  delay(10);
+
+  // DCDC → main CS only
+  _sendCmdDataCS0(RA5_DCDC, DCDC_V, sizeof(DCDC_V));
+  delay(10);
+
+  // CDI (VCOM and data interval) → both
+  _sendCmdDataBoth(R50_CDI, CDI_V, sizeof(CDI_V));
+  delay(10);
+
+  // 0x60 (Gate/Source timing) → both
+  _sendCmdDataBoth(0x60, r60, sizeof(r60));
+  delay(10);
+
+  // 0x86 → both
+  _sendCmdDataBoth(0x86, r86, sizeof(r86));
+  delay(10);
+
+  // PWS (Power Saving) → both
+  _sendCmdDataBoth(RE3_PWS, PWS_V, sizeof(PWS_V));
+  delay(10);
+
+  // TRES (Resolution) → both
+  _sendCmdDataBoth(R61_TRES, TRES_V, sizeof(TRES_V));
+  delay(10);
+
+  // PWR (Power Setting) → main CS only
+  _sendCmdDataCS0(R01_PWR, PWR_V, sizeof(PWR_V));
+  delay(10);
+
+  // Boost timing parameters → main CS only
+  _sendCmdDataCS0(0xB6, rb6, sizeof(rb6));
+  delay(10);
+  _sendCmdDataCS0(R06_BTST_P, BTST_P_V, sizeof(BTST_P_V));
+  delay(10);
+  _sendCmdDataCS0(0xB7, rb7, sizeof(rb7));
+  delay(10);
+  _sendCmdDataCS0(R05_BTST_N, BTST_N_V, sizeof(BTST_N_V));
+  delay(10);
+  _sendCmdDataCS0(0xB0, rb0, sizeof(rb0));
+  delay(10);
+  _sendCmdDataCS0(0xB1, rb1, sizeof(rb1));
+  delay(10);
+
+  _init_display_done = true;
+  _initial_write = false;
+}
+
+// ---- Power control (both chips) ----
+
+void GxEPD2_T133A01_1200x1600::_PowerOnBoth()
+{
+  if (_power_is_on) return;
+  _sendCmdDataBoth(R04_PON, nullptr, 0);
+  _checkBusy("PON(PowerOnBoth)", 5000);
+  _power_is_on = true;
+}
+
+void GxEPD2_T133A01_1200x1600::_PowerOffBoth()
+{
+  if (!_power_is_on) return;
+  _sendCmdDataBoth(R02_POF, POF_V, sizeof(POF_V));
+  _checkBusy("POF(PowerOffBoth)", 5000);
+  _power_is_on = false;
+}
+
+// ---- Frame buffer ----
+
+void GxEPD2_T133A01_1200x1600::clearScreen(uint8_t value)
+{
+  _fillFrameBuffer(0xFF == value ? 0x11 : 0x00);
+  refresh();
+}
+
+void GxEPD2_T133A01_1200x1600::writeScreenBuffer(uint8_t value)
+{
+  writeScreenBuffer(value, 0xFF);
+}
+
+void GxEPD2_T133A01_1200x1600::writeScreenBuffer(uint8_t black_value, uint8_t color_value)
+{
+  _allocFrameBuffer();
+  _fillFrameBuffer(0xFF == black_value ? 0x11 : 0x00);
+}
+
+void GxEPD2_T133A01_1200x1600::setPaged()
+{
+  _paged = true;
+}
+
+// ---- writeNative: copy 4bpp GxEPD2 page data into PSRAM framebuffer ----
+
+void GxEPD2_T133A01_1200x1600::writeNative(const uint8_t* data1, const uint8_t* data2,
+    int16_t x, int16_t y, int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (!data1) return;
+  _allocFrameBuffer();
+  uint32_t wb = (w + 1) / 2;
+  for (int16_t row = 0; row < h; row++) {
+    int16_t dst_y = y + row;
+    if (dst_y < 0 || dst_y >= HEIGHT) continue;
+    for (int16_t col = 0; col < (int16_t)wb; col++) {
+      int16_t dst_x2 = x / 2 + col;
+      if (dst_x2 < 0 || dst_x2 >= (int16_t)BYTES_PER_ROW) continue;
+      uint32_t src_idx = mirror_y ? col + uint32_t(h - 1 - row) * wb
+                                  : col + uint32_t(row) * wb;
+      uint8_t data;
+      if (pgm) {
+#if defined(__AVR) || defined(ESP8266) || defined(ESP32)
+        data = pgm_read_byte(&data1[src_idx]);
+#else
+        data = data1[src_idx];
+#endif
+      } else {
+        data = data1[src_idx];
+      }
+      _frame_buf[uint32_t(dst_y) * BYTES_PER_ROW + dst_x2] = data;
+    }
+  }
+}
+
+void GxEPD2_T133A01_1200x1600::writeNativePart(
+    const uint8_t* data1, const uint8_t* data2,
+    int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+    int16_t x, int16_t y, int16_t w, int16_t h,
+    bool invert, bool mirror_y, bool pgm)
+{
+  if (!data1) return;
+  _allocFrameBuffer();
+  if ((w_bitmap < 0) || (h_bitmap < 0) || (w < 0) || (h < 0)) return;
+  if ((x_part < 0) || (x_part >= w_bitmap)) return;
+  if ((y_part < 0) || (y_part >= h_bitmap)) return;
+  uint32_t wb_bitmap = (w_bitmap + 1) / 2;
+  w = w_bitmap - x_part < w ? w_bitmap - x_part : w;
+  h = h_bitmap - y_part < h ? h_bitmap - y_part : h;
+  uint32_t wb = (w + 1) / 2;
+  for (int16_t row = 0; row < h; row++) {
+    int16_t dst_y = y + row;
+    if (dst_y < 0 || dst_y >= HEIGHT) continue;
+    for (int16_t col = 0; col < (int16_t)wb; col++) {
+      int16_t dst_x2 = x / 2 + col;
+      if (dst_x2 < 0 || dst_x2 >= (int16_t)BYTES_PER_ROW) continue;
+      uint32_t src_idx = mirror_y
+        ? x_part / 2 + col + uint32_t(h_bitmap - 1 - (y_part + row)) * wb_bitmap
+        : x_part / 2 + col + uint32_t(y_part + row) * wb_bitmap;
+      uint8_t data;
+      if (pgm) {
+#if defined(__AVR) || defined(ESP8266) || defined(ESP32)
+        data = pgm_read_byte(&data1[src_idx]);
+#else
+        data = data1[src_idx];
+#endif
+      } else {
+        data = data1[src_idx];
+      }
+      _frame_buf[uint32_t(dst_y) * BYTES_PER_ROW + dst_x2] = data;
+    }
+  }
+}
+
+// ---- writeImage: convert 1bpp B&W bitmap to 4bpp ----
+
+void GxEPD2_T133A01_1200x1600::writeImage(const uint8_t bitmap[], int16_t x, int16_t y,
+    int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  if (!bitmap) return;
+  _allocFrameBuffer();
+  int16_t wb = (w + 7) / 8;
+  for (int16_t row = 0; row < h; row++) {
+    int16_t dst_y = y + row;
+    if (dst_y < 0 || dst_y >= HEIGHT) continue;
+    for (int16_t col = 0; col < w; col++) {
+      int16_t dst_x = x + col;
+      if (dst_x < 0 || dst_x >= WIDTH) continue;
+      uint32_t src_idx = mirror_y ? col / 8 + uint32_t(h - 1 - row) * wb
+                                  : col / 8 + uint32_t(row) * wb;
+      uint8_t byte_val;
+      if (pgm) {
+#if defined(__AVR) || defined(ESP8266) || defined(ESP32)
+        byte_val = pgm_read_byte(&bitmap[src_idx]);
+#else
+        byte_val = bitmap[src_idx];
+#endif
+      } else {
+        byte_val = bitmap[src_idx];
+      }
+      if (invert) byte_val = ~byte_val;
+      bool white = byte_val & (0x80 >> (col & 7));
+      uint8_t color7 = white ? 0x01 : 0x00;
+      uint32_t fb_idx = uint32_t(dst_y) * BYTES_PER_ROW + dst_x / 2;
+      if (dst_x & 1) _frame_buf[fb_idx] = (_frame_buf[fb_idx] & 0xF0) | color7;
+      else           _frame_buf[fb_idx] = (_frame_buf[fb_idx] & 0x0F) | (color7 << 4);
+    }
+  }
+}
+
+void GxEPD2_T133A01_1200x1600::writeImagePart(const uint8_t bitmap[],
+    int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+    int16_t x, int16_t y, int16_t w, int16_t h,
+    bool invert, bool mirror_y, bool pgm)
+{
+  writeImage(bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_T133A01_1200x1600::writeImage(const uint8_t* black, const uint8_t* color,
+    int16_t x, int16_t y, int16_t w, int16_t h,
+    bool invert, bool mirror_y, bool pgm)
+{
+  if (black) writeImage(black, x, y, w, h, invert, mirror_y, pgm);
+}
+
+void GxEPD2_T133A01_1200x1600::writeImagePart(const uint8_t* black, const uint8_t* color,
+    int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+    int16_t x, int16_t y, int16_t w, int16_t h,
+    bool invert, bool mirror_y, bool pgm)
+{
+  if (black) writeImagePart(black, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+}
+
+// ---- draw variants (write + refresh) ----
+
+void GxEPD2_T133A01_1200x1600::drawImage(const uint8_t bitmap[], int16_t x, int16_t y,
+    int16_t w, int16_t h, bool invert, bool mirror_y, bool pgm)
+{
+  writeImage(bitmap, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+}
+
+void GxEPD2_T133A01_1200x1600::drawImagePart(const uint8_t bitmap[],
+    int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+    int16_t x, int16_t y, int16_t w, int16_t h,
+    bool invert, bool mirror_y, bool pgm)
+{
+  writeImagePart(bitmap, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+}
+
+void GxEPD2_T133A01_1200x1600::drawImage(const uint8_t* black, const uint8_t* color,
+    int16_t x, int16_t y, int16_t w, int16_t h,
+    bool invert, bool mirror_y, bool pgm)
+{
+  writeImage(black, color, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+}
+
+void GxEPD2_T133A01_1200x1600::drawImagePart(const uint8_t* black, const uint8_t* color,
+    int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+    int16_t x, int16_t y, int16_t w, int16_t h,
+    bool invert, bool mirror_y, bool pgm)
+{
+  writeImagePart(black, color, x_part, y_part, w_bitmap, h_bitmap, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+}
+
+void GxEPD2_T133A01_1200x1600::drawNative(const uint8_t* data1, const uint8_t* data2,
+    int16_t x, int16_t y, int16_t w, int16_t h,
+    bool invert, bool mirror_y, bool pgm)
+{
+  writeNative(data1, data2, x, y, w, h, invert, mirror_y, pgm);
+  refresh(x, y, w, h);
+}
+
+// ---- Send framebuffer to both chips and trigger display refresh ----
+
+// Strict port of Seeed_GFX EPD_PUSH_NEW_COLORS:
+//   - CS toggling happens OUTSIDE SPI transactions
+//   - master CS and slave CS1 are kept mutually exclusive
+//   - DC and SPI transaction order matches Seeed exactly
+void GxEPD2_T133A01_1200x1600::_sendFrameToDisplay()
+{
+  if (!_init_display_done) _InitDisplay();
+
+  unsigned long t0 = millis();
+  uint32_t bytes_chip0 = 0;
+  uint32_t bytes_chip1 = 0;
+
+  // CCSET → both chips
+  _sendCmdDataBoth(RE0_CCSET, CCSET_CUR, sizeof(CCSET_CUR));
+  _checkBusy("CCSET", 1000);
+  delay(10);
+
+  // ------ Chip 0 (master, CS): LEFT half of each row ------
+  // (CS toggling outside the SPI transaction, mirroring Seeed_GFX)
+  digitalWrite(_cs1, HIGH);              // slave NOT selected
+  if (_cs >= 0) digitalWrite(_cs, LOW);  // master selected
+  _pSPIx->beginTransaction(_spi_settings);
+  if (_dc >= 0) digitalWrite(_dc, LOW);
+  _pSPIx->transfer(R10_DTM);
+  if (_dc >= 0) digitalWrite(_dc, HIGH);
+  for (uint16_t row = 0; row < HEIGHT; row++) {
+    const uint8_t* rp = _frame_buf + uint32_t(row) * BYTES_PER_ROW;
+    for (uint16_t col = 0; col < HALF_W_BYTES; col++) {
+      _pSPIx->transfer(_convert_to_native(rp[col]));
+      bytes_chip0++;
+    }
+    if ((row & 0x3F) == 0) yield();
+  }
+  _pSPIx->endTransaction();
+  if (_cs >= 0) digitalWrite(_cs, HIGH); // master deselected
+
+  if (_diag_enabled) {
+    DBG.print(F("[T133A01] chip0 sent "));
+    DBG.print(bytes_chip0);
+    DBG.println(F(" bytes (left half)"));
+  }
+
+  delay(10); // small settle time before re-asserting the other CS
+
+  // ------ Chip 1 (slave, CS1): RIGHT half of each row ------
+  digitalWrite(_cs1, LOW);               // slave selected
+  _pSPIx->beginTransaction(_spi_settings);
+  if (_dc >= 0) digitalWrite(_dc, LOW);
+  _pSPIx->transfer(R10_DTM);
+  if (_dc >= 0) digitalWrite(_dc, HIGH);
+  for (uint16_t row = 0; row < HEIGHT; row++) {
+    const uint8_t* rp = _frame_buf + uint32_t(row) * BYTES_PER_ROW;
+    for (uint16_t col = HALF_W_BYTES; col < BYTES_PER_ROW; col++) {
+      _pSPIx->transfer(_convert_to_native(rp[col]));
+      bytes_chip1++;
+    }
+    if ((row & 0x3F) == 0) yield();
+  }
+  _pSPIx->endTransaction();
+  digitalWrite(_cs1, HIGH);              // slave deselected
+
+  if (_diag_enabled) {
+    DBG.print(F("[T133A01] chip1 sent "));
+    DBG.print(bytes_chip1);
+    DBG.println(F(" bytes (right half)"));
+    unsigned long dt = millis() - t0;
+    DBG.print(F("[T133A01] data xfer ms = "));
+    DBG.println(dt);
+  }
+}
+
+void GxEPD2_T133A01_1200x1600::refresh(bool partial_update_mode)
+{
+  _sendFrameToDisplay();
+
+  unsigned long t0 = millis();
+
+  // EPD_UPDATE sequence: PON → DRF → POF (both chips)
+  // NOTE: a real full-screen 7-color refresh on this 13.3" panel takes
+  //       roughly 30~40 seconds, so DRF needs a long timeout.
+  _sendCmdDataBoth(R04_PON, nullptr, 0);
+  _checkBusy("PON", 5000);            // power-on usually < 1 s
+  delay(30);
+
+  _sendCmdDataBoth(R12_DRF, DRF_V, sizeof(DRF_V));
+  _checkBusy("DRF", 60000);           // 7-color refresh: 30~40 s, give 60 s
+  delay(30);
+
+  _sendCmdDataBoth(R02_POF, POF_V, sizeof(POF_V));
+  _checkBusy("POF", 5000);
+  delay(30);
+
+  _power_is_on = false;
+
+  if (_diag_enabled) {
+    unsigned long dt = millis() - t0;
+    DBG.print(F("[T133A01] refresh ms = "));
+    DBG.println(dt);
+  }
+}
+
+void GxEPD2_T133A01_1200x1600::refresh(int16_t x, int16_t y, int16_t w, int16_t h)
+{
+  refresh(false);
+}
+
+void GxEPD2_T133A01_1200x1600::powerOff()
+{
+  _PowerOffBoth();
+}
+
+void GxEPD2_T133A01_1200x1600::hibernate()
+{
+  _PowerOffBoth();
+  if (_rst >= 0) {
+    uint8_t sleep_val = 0xA5;
+    _sendCmdDataBoth(0x07, &sleep_val, 1);
+    _hibernating = true;
+    _init_display_done = false;
+  }
+}

--- a/clients/reterminal_e1004/GxEPD2_T133A01_1200x1600.h
+++ b/clients/reterminal_e1004/GxEPD2_T133A01_1200x1600.h
@@ -1,0 +1,131 @@
+// GxEPD2 driver class for the T133A01 (13.3", 1200 x 1600, 7-color)
+// panel as wired on the Seeed Studio reTerminal E1004 (BOARD_SCREEN_COMBO 523).
+//
+// The T133A01 uses a dual-chip architecture: two ePaper controllers
+// share the display, each driving half the image columns.
+//   - Chip 0 (CS, GPIO 10): left  600 pixels of every row
+//   - Chip 1 (CS1, GPIO 2): right 600 pixels of every row
+//
+// GxEPD2 has no built-in driver for this panel.  This file provides
+// an alternative driver in the example folder.  Move the .h/.cpp pair
+// next to your sketch to reuse it elsewhere.
+//
+// Reference (working implementation):
+//   Seeed_GFX/TFT_Drivers/T133A01_Defines.h   - registers, init, data transfer
+//   Seeed_GFX/TFT_Drivers/T133A01_Init.h       - pin setup
+//   Seeed_GFX/Extensions/EPaper.cpp             - update/pushColors flow
+//
+// Memory note: we keep a full-screen 4bpp framebuffer in PSRAM
+//   (1200 * 1600 / 2 = 960 000 bytes, ~937 KB).
+//   PSRAM is mandatory: select  Tools > PSRAM: OPI PSRAM  on XIAO_ESP32S3.
+
+#ifndef _GxEPD2_T133A01_1200x1600_H_
+#define _GxEPD2_T133A01_1200x1600_H_
+
+#include <Arduino.h>
+#include <GxEPD2_EPD.h>
+
+class GxEPD2_T133A01_1200x1600 : public GxEPD2_EPD
+{
+  public:
+    static const uint16_t WIDTH = 1200;
+    static const uint16_t WIDTH_VISIBLE = WIDTH;
+    static const uint16_t HEIGHT = 1600;
+    static const GxEPD2::Panel panel = GxEPD2::GDEP073E01;
+    static const bool hasColor = true;
+    static const bool hasPartialUpdate = false;
+    static const bool usePartialUpdate = false;
+    static const bool hasFastPartialUpdate = false;
+    static const uint16_t power_on_time = 300;
+    static const uint16_t power_off_time = 200;
+    static const uint16_t full_refresh_time = 30000;
+    static const uint16_t partial_refresh_time = 30000;
+
+    GxEPD2_T133A01_1200x1600(int16_t cs, int16_t dc, int16_t rst,
+                               int16_t busy, int16_t cs1, int16_t enable);
+
+    void init(uint32_t serial_diag_bitrate = 0) override;
+    void init(uint32_t serial_diag_bitrate, bool initial,
+              uint16_t reset_duration = 10, bool pulldown_rst_mode = false) override;
+
+    void clearScreen(uint8_t value = 0xFF) override;
+    void writeScreenBuffer(uint8_t value = 0xFF) override;
+    void writeScreenBuffer(uint8_t black_value, uint8_t color_value);
+
+    void writeImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h,
+                    bool invert = false, bool mirror_y = false, bool pgm = false) override;
+    void writeImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part,
+                        int16_t w_bitmap, int16_t h_bitmap,
+                        int16_t x, int16_t y, int16_t w, int16_t h,
+                        bool invert = false, bool mirror_y = false, bool pgm = false) override;
+
+    void writeImage(const uint8_t* black, const uint8_t* color,
+                    int16_t x, int16_t y, int16_t w, int16_t h,
+                    bool invert = false, bool mirror_y = false, bool pgm = false);
+    void writeImagePart(const uint8_t* black, const uint8_t* color,
+                        int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                        int16_t x, int16_t y, int16_t w, int16_t h,
+                        bool invert = false, bool mirror_y = false, bool pgm = false);
+
+    void writeNative(const uint8_t* data1, const uint8_t* data2,
+                     int16_t x, int16_t y, int16_t w, int16_t h,
+                     bool invert = false, bool mirror_y = false, bool pgm = false);
+    void writeNativePart(const uint8_t* data1, const uint8_t* data2,
+                         int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                         int16_t x, int16_t y, int16_t w, int16_t h,
+                         bool invert = false, bool mirror_y = false, bool pgm = false);
+
+    void drawImage(const uint8_t bitmap[], int16_t x, int16_t y, int16_t w, int16_t h,
+                   bool invert = false, bool mirror_y = false, bool pgm = false);
+    void drawImagePart(const uint8_t bitmap[], int16_t x_part, int16_t y_part,
+                       int16_t w_bitmap, int16_t h_bitmap,
+                       int16_t x, int16_t y, int16_t w, int16_t h,
+                       bool invert = false, bool mirror_y = false, bool pgm = false);
+    void drawImage(const uint8_t* black, const uint8_t* color,
+                   int16_t x, int16_t y, int16_t w, int16_t h,
+                   bool invert = false, bool mirror_y = false, bool pgm = false);
+    void drawImagePart(const uint8_t* black, const uint8_t* color,
+                       int16_t x_part, int16_t y_part, int16_t w_bitmap, int16_t h_bitmap,
+                       int16_t x, int16_t y, int16_t w, int16_t h,
+                       bool invert = false, bool mirror_y = false, bool pgm = false);
+    void drawNative(const uint8_t* data1, const uint8_t* data2,
+                    int16_t x, int16_t y, int16_t w, int16_t h,
+                    bool invert = false, bool mirror_y = false, bool pgm = false);
+
+    void refresh(bool partial_update_mode = false) override;
+    void refresh(int16_t x, int16_t y, int16_t w, int16_t h) override;
+    void powerOff() override;
+    void hibernate() override;
+    void setPaged() override;
+
+  private:
+    static constexpr uint32_t BYTES_PER_ROW = WIDTH / 2;
+    static constexpr uint32_t FRAME_BYTES = uint32_t(BYTES_PER_ROW) * HEIGHT;
+    static constexpr uint16_t HALF_W_BYTES = WIDTH / 4;
+
+    int16_t _cs1;
+    int16_t _enable;
+    uint8_t* _frame_buf;
+    bool _paged;
+
+    void _allocFrameBuffer();
+    void _fillFrameBuffer(uint8_t gxepd2_value);
+    uint8_t _convert_to_native(uint8_t data);
+
+    void _sendCmdDataBoth(uint8_t cmd, const uint8_t* data, uint16_t len);
+    void _sendCmdDataCS0(uint8_t cmd, const uint8_t* data, uint16_t len);
+
+    // Custom busy wait: matches Seeed_GFX CHECK_BUSY() exactly
+    //   - 10 ms blocking delay BEFORE the first poll (gives the chip time
+    //     to actually drive BUSY low after receiving a command),
+    //   - poll the BUSY pin every 10 ms thereafter,
+    //   - generous timeout so a real 7-color refresh has room to finish.
+    void _checkBusy(const char* tag, uint32_t timeout_ms);
+
+    void _InitDisplay();
+    void _PowerOnBoth();
+    void _PowerOffBoth();
+    void _sendFrameToDisplay();
+};
+
+#endif

--- a/clients/reterminal_e1004/README.md
+++ b/clients/reterminal_e1004/README.md
@@ -1,0 +1,95 @@
+# Seeed reTerminal E1004 as a hokku screen
+
+Arduino client that lets a [Seeed Studio reTerminal E1004](https://www.seeedstudio.com/reTerminal-E1004-p-6692.html)
+(13.3" E Ink Spectra 6, 1200×1600, ESP32-S3) pull and display images from a hokku
+server — same wire protocol, same server-side dithering pipeline as the stock
+Hokku/Huessen frame. **No server changes required**: the device shows up in the
+Connected Screens dashboard on its first request, battery percentage included.
+
+Both frames use the same 13.3" Spectra 6 glass, but the E1004's panel (T133A01)
+has a different controller wiring (single SPI bus, two chip-selects, one per
+600-px half), so this is a standalone client sketch rather than a port of the
+main firmware.
+
+## Files
+
+| file | what |
+|---|---|
+| `reterminal_e1004.ino` | the client: WiFi → GET `/hokku/screen/` → decode → display → deep sleep |
+| `GxEPD2_T133A01_1200x1600.cpp/.h` | panel driver, vendored from [Seeed_GxEPD2](https://github.com/Seeed-Projects/Seeed_GxEPD2) `examples/GxEPD2_reTerminal_E1004/` (GPL-3.0, same as this repo) |
+
+## Build
+
+Arduino IDE or arduino-cli with the espressif `esp32` core (tested: 3.3.10) and
+the **Adafruit GFX** + **[Seeed_GxEPD2](https://github.com/Seeed-Projects/Seeed_GxEPD2)** libraries.
+
+Board settings (critical):
+
+```
+Board:  XIAO_ESP32S3
+PSRAM:  OPI PSRAM        <- mandatory; the 4bpp framebuffer is ~937 KB
+```
+
+arduino-cli one-liners:
+
+```sh
+arduino-cli compile --fqbn "esp32:esp32:XIAO_ESP32S3:PSRAM=opi" --libraries <path-to-libraries> .
+arduino-cli upload  -p <port> --fqbn "esp32:esp32:XIAO_ESP32S3:PSRAM=opi" .
+```
+
+Edit the config block at the top of the sketch first: WiFi credentials, server
+IP/port, screen name. `DEEP_SLEEP 0` keeps the board awake between refreshes
+(USB serial stays up — use while bring-up/debugging), `1` deep-sleeps for
+`X-Sleep-Seconds` between fetches for battery deployment.
+
+## Pinout (E1004, dual-chip T133A01)
+
+Taken from Seeed's shipped example — note the wiki's pin table is wrong about
+RST at the time of writing:
+
+| signal | GPIO |
+|---|---|
+| SCK / MISO / MOSI | 7 / 8 / 9 |
+| CS (chip 0, left half) | 10 |
+| DC | 11 |
+| CS1 (chip 1, right half) | 2 |
+| RST | **38** (wiki says 12 — that's actually ENABLE) |
+| BUSY | 13 |
+| ENABLE | 12 |
+| battery ADC / enable | 1 / 21 (2× divider; drive 21 HIGH to read) |
+
+## How the panel data path works
+
+hokku's `/hokku/screen/` returns exactly 960,000 bytes: two 600×1600 halves
+back-to-back, row-major, two pixels per byte (high nibble = even column), with
+the Spectra-6 nibble palette `0x0` black / `0x1` white / `0x2` yellow /
+`0x3` red / `0x5` blue / `0x6` green — see `docs/` and
+`webserver/hokku_server/display.py`.
+
+That left/right split maps 1:1 onto the E1004's two controller chips, so the
+sketch never touches individual pixels: it remaps each byte through a 256-entry
+LUT and hands each half straight to the driver's `writeNative()`.
+
+The LUT exists because of an encoding subtlety: the GxEPD2 driver's framebuffer
+stores GxEPD2 color *indices* (0=black 1=white 2=green 3=blue 4=red 5=yellow)
+and converts them to the panel's native nibbles only when shifting data out
+over SPI. hokku's wire format is already panel-native — which happens to be the
+identical palette — so the sketch applies the *inverse* of the driver's mapping
+first and the two conversions cancel out. Colors and orientation then come out
+correct with no rotation or mirroring.
+
+## Protocol niceties implemented
+
+- `X-Screen-Name` request header → auto-registers in the dashboard
+- `X-Battery-mV` request header → battery % in the dashboard (ADC GPIO1,
+  enable GPIO21, 2× divider — same circuit as the E1001/E1002)
+- `X-Sleep-Seconds` response header honored for the deep-sleep interval,
+  including on 404/503 "no image yet" responses
+- Full refresh takes ~30 s (panel physics); complete wake→fetch→display cycle
+  measured at ~30 s on a 2.4 GHz network
+
+---
+
+*Developed against hokku 3.1.0-alpha1 on a stock E1004 (ESP32-S3 rev v0.2,
+8 MB PSRAM, 32 MB flash). Written up with the help of Claude (Anthropic) as a
+pair-programming assistant.*

--- a/clients/reterminal_e1004/reterminal_e1004.ino
+++ b/clients/reterminal_e1004/reterminal_e1004.ino
@@ -1,0 +1,211 @@
+﻿// e1004_hokku.ino  ?? Method 2a
+// Seeed reTerminal E1004 (13.3" Spectra 6) as a client of the hokku photo server.
+//
+// Flow:  wake -> WiFi -> GET http://<server>/hokku/screen/  (X-Screen-Name header)
+//        -> read 960,000-byte packed panel buffer
+//        -> remap hokku native nibbles -> GxEPD2 encoding (byte LUT)
+//        -> writeNative() the two 600-wide halves into the panel framebuffer
+//        -> refresh() (~40 s)  -> sleep for X-Sleep-Seconds, repeat.
+//
+// The hokku wire format (server display.py):
+//   image is 1200(w) x 1600(h), split into two physical 600x1600 halves.
+//   bytes[0       .. 479999] = LEFT  half  (1600 rows x 300 bytes, 2 px/byte)
+//   bytes[480000  .. 959999] = RIGHT half
+//   per byte: high nibble = even column, low nibble = odd column.
+//   nibble palette: 0x0 black, 0x1 white, 0x2 yellow, 0x3 red, 0x5 blue, 0x6 green
+//   ...which is IDENTICAL to the T133A01 native palette.
+//
+// Board: XIAO_ESP32S3,  PSRAM: OPI PSRAM  (two 960 KB PSRAM buffers needed).
+
+#include <SPI.h>
+#include <WiFi.h>
+#include <HTTPClient.h>
+#include <esp_sleep.h>
+#include <esp_heap_caps.h>
+#include <GxEPD2_7C.h>
+#include "GxEPD2_T133A01_1200x1600.h"
+
+// ---------- USER CONFIG ----------
+static const char*    WIFI_SSID   = "YOUR_WIFI_SSID";
+static const char*    WIFI_PASS   = "YOUR_WIFI_PASSWORD";
+static const char*    SERVER_HOST = "192.168.1.100";
+static const uint16_t SERVER_PORT = 8080;
+static const char*    SCREEN_NAME = "E1004";   // shows as its own screen in the hokku dashboard
+static const uint32_t DEFAULT_SLEEP_S = 1800;             // fallback if server sends no X-Sleep-Seconds
+#define DEEP_SLEEP 1     // 0 = stay awake & loop (easy dev/reflash). 1 = deep sleep (battery deployment).
+// ---------------------------------
+
+// Pin mapping (from the official E1004 example ??dual-chip panel)
+#define EPD_SCK_PIN    7
+#define EPD_MISO_PIN   8
+#define EPD_MOSI_PIN   9
+#define EPD_CS_PIN     10
+#define EPD_DC_PIN     11
+#define EPD_CS1_PIN    2
+#define EPD_RES_PIN    38
+#define EPD_BUSY_PIN   13
+#define EPD_ENABLE_PIN 12
+
+static const uint32_t EXPECT_BYTES = 960000;   // 1200*1600/2
+static const uint32_t HALF_BYTES   = 480000;   // one 600x1600 half
+
+// Battery sense (E-series documented values; E1004 assumed same ??VERIFY via serial).
+#define BAT_ADC_PIN     1     // ADC1_CH0 (A0) ??battery voltage (through 2x divider)
+#define BAT_ENABLE_PIN  21    // must be HIGH to enable the divider, else reads garbage
+#define BAT_DIVIDER     2.0f
+
+SPIClass hspi(HSPI);
+GxEPD2_T133A01_1200x1600 epd(EPD_CS_PIN, EPD_DC_PIN, EPD_RES_PIN,
+                             EPD_BUSY_PIN, EPD_CS1_PIN, EPD_ENABLE_PIN);
+
+static uint8_t* g_buf = nullptr;     // 960 KB PSRAM image buffer
+static uint8_t  g_byteLUT[256];      // hokku-native byte -> GxEPD2-encoded byte
+static uint32_t g_sleepS = DEFAULT_SLEEP_S;
+
+// Build the byte lookup table: each nibble hokku-native -> GxEPD2 color index.
+// GxEPD2 color7 index: 0 black, 1 white, 2 green, 3 blue, 4 red, 5 yellow, 6 orange.
+// The driver maps those back to native at send time, so we invert here.
+static void buildByteLUT() {
+  uint8_t inv[16];
+  for (int i = 0; i < 16; i++) inv[i] = 1;   // default white
+  inv[0x0] = 0;  // black
+  inv[0x1] = 1;  // white
+  inv[0x2] = 5;  // yellow
+  inv[0x3] = 4;  // red
+  inv[0x5] = 3;  // blue
+  inv[0x6] = 2;  // green
+  for (int b = 0; b < 256; b++)
+    g_byteLUT[b] = (inv[(b >> 4) & 0x0F] << 4) | inv[b & 0x0F];
+}
+
+// Read battery voltage in mV (averaged). Returns 0 if it looks invalid.
+static int readBatteryMv() {
+  pinMode(BAT_ENABLE_PIN, OUTPUT);
+  digitalWrite(BAT_ENABLE_PIN, HIGH);
+  delay(50);
+  analogSetPinAttenuation(BAT_ADC_PIN, ADC_11db);
+  uint32_t sum = 0;
+  for (int i = 0; i < 16; i++) { sum += analogReadMilliVolts(BAT_ADC_PIN); delay(2); }
+  digitalWrite(BAT_ENABLE_PIN, LOW);
+  int pin_mv = sum / 16;
+  int batt_mv = (int)(pin_mv * BAT_DIVIDER);
+  Serial.printf("[batt] pin=%d mV  -> battery=%d mV\n", pin_mv, batt_mv);
+  if (batt_mv < 2500 || batt_mv > 4500) return 0;   // sanity gate
+  return batt_mv;
+}
+
+static bool connectWiFi(uint32_t timeout_ms = 20000) {
+  if (WiFi.status() == WL_CONNECTED) return true;
+  Serial.printf("[wifi] connecting to %s ...\n", WIFI_SSID);
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(WIFI_SSID, WIFI_PASS);
+  uint32_t t0 = millis();
+  while (WiFi.status() != WL_CONNECTED && millis() - t0 < timeout_ms) {
+    delay(250); Serial.print('.');
+  }
+  Serial.println();
+  if (WiFi.status() == WL_CONNECTED) {
+    Serial.printf("[wifi] connected, IP=%s\n", WiFi.localIP().toString().c_str());
+    return true;
+  }
+  Serial.println("[wifi] FAILED");
+  return false;
+}
+
+// Fetch + display one image. Returns seconds to sleep before the next call.
+static uint32_t doUpdate() {
+  uint32_t sleepS = DEFAULT_SLEEP_S;
+  if (!connectWiFi()) return 60;   // retry soon on WiFi failure
+
+  if (!g_buf) {
+    g_buf = (uint8_t*)ps_malloc(EXPECT_BYTES);
+    if (!g_buf) { Serial.println("[mem] ps_malloc 960KB FAILED"); return 300; }
+  }
+
+  WiFiClient client;
+  HTTPClient http;
+  String url = String("http://") + SERVER_HOST + ":" + SERVER_PORT + "/hokku/screen/";
+  Serial.printf("[http] GET %s\n", url.c_str());
+  http.begin(client, url);
+  http.addHeader("X-Screen-Name", SCREEN_NAME);
+  int batt_mv = readBatteryMv();
+  if (batt_mv > 0) http.addHeader("X-Battery-mV", String(batt_mv));
+  const char* collect[] = {"X-Sleep-Seconds"};
+  http.collectHeaders(collect, 1);
+  http.setTimeout(20000);
+
+  int code = http.GET();
+  Serial.printf("[http] status=%d  len=%d\n", code, http.getSize());
+
+  if (http.hasHeader("X-Sleep-Seconds")) {
+    long s = http.header("X-Sleep-Seconds").toInt();
+    if (s > 0) sleepS = (uint32_t)s;
+    Serial.printf("[http] X-Sleep-Seconds=%lu\n", (unsigned long)sleepS);
+  }
+
+  if (code != 200) {
+    Serial.println("[http] no image this cycle (will retry after sleep)");
+    http.end();
+    return sleepS;
+  }
+
+  // Read the 960,000-byte body into PSRAM.
+  WiFiClient* st = http.getStreamPtr();
+  uint32_t got = 0;
+  uint32_t deadline = millis() + 30000;
+  while (got < EXPECT_BYTES && millis() < deadline) {
+    size_t avail = st->available();
+    if (avail) {
+      uint32_t want = EXPECT_BYTES - got;
+      int r = st->readBytes(g_buf + got, avail < want ? avail : want);
+      if (r > 0) { got += r; deadline = millis() + 30000; }
+    } else {
+      if (!http.connected()) break;
+      delay(2);
+    }
+  }
+  http.end();
+  Serial.printf("[http] received %lu / %lu bytes\n", (unsigned long)got, (unsigned long)EXPECT_BYTES);
+  if (got != EXPECT_BYTES) { Serial.println("[http] short read, skipping draw"); return sleepS; }
+
+  // Remap hokku-native bytes -> GxEPD2 encoding in place.
+  for (uint32_t i = 0; i < EXPECT_BYTES; i++) g_buf[i] = g_byteLUT[g_buf[i]];
+
+  // Push the two halves into the panel framebuffer, then refresh.
+  Serial.println("[epd] writing framebuffer + refresh (~40s)...");
+  uint32_t t0 = millis();
+  epd.writeNative(g_buf,             nullptr, 0,   0, 600, 1600);  // left  half -> cols 0..599
+  epd.writeNative(g_buf + HALF_BYTES, nullptr, 600, 0, 600, 1600); // right half -> cols 600..1199
+  epd.refresh(false);
+  epd.hibernate();
+  Serial.printf("[epd] done in %lu ms\n", (unsigned long)(millis() - t0));
+  return sleepS;
+}
+
+void setup() {
+  Serial.begin(115200);
+  delay(400);
+  Serial.println("\n[E1004-hokku] boot");
+
+  buildByteLUT();
+  hspi.begin(EPD_SCK_PIN, EPD_MISO_PIN, EPD_MOSI_PIN, -1);
+  epd.selectSPI(hspi, SPISettings(10000000, MSBFIRST, SPI_MODE0));
+  epd.init(115200);
+
+  g_sleepS = doUpdate();
+
+#if DEEP_SLEEP
+  Serial.printf("[sleep] deep sleep %lu s\n", (unsigned long)g_sleepS);
+  WiFi.disconnect(true);
+  esp_sleep_enable_timer_wakeup((uint64_t)g_sleepS * 1000000ULL);
+  esp_deep_sleep_start();   // resets and re-runs setup() on wake
+#endif
+}
+
+void loop() {
+#if !DEEP_SLEEP
+  Serial.printf("[sleep] awake-wait %lu s then re-fetch\n", (unsigned long)g_sleepS);
+  delay(g_sleepS * 1000UL);
+  g_sleepS = doUpdate();
+#endif
+}


### PR DESCRIPTION
Follows up on #14 - as requested, here's the code that lets a Seeed reTerminal E1004 work as a hokku screen.

**What's included** (all under `clients/reterminal_e1004/`):
- `reterminal_e1004.ino` - standalone Arduino client: WiFi -> `GET /hokku/screen/` (with `X-Screen-Name` / `X-Battery-mV`) -> decode the 960 KB payload -> display -> deep sleep per `X-Sleep-Seconds`. No server changes needed; it auto-registers in the dashboard with battery %.
- `GxEPD2_T133A01_1200x1600.cpp/.h` - panel driver vendored from Seeed_GxEPD2 examples (GPL-3.0, same license as this repo).
- `README.md` - build instructions, verified pinout (the Seeed wiki's RST pin is wrong), and the color-encoding details.

**The one non-obvious part:** hokku's wire format is already panel-native for this glass (same Spectra 6 nibble palette), but the GxEPD2 driver's framebuffer stores GxEPD2 color indices and converts to native at SPI-out time - so the client remaps each byte through the inverse LUT first and the two conversions cancel. The left/right 600px halves map 1:1 onto the T133A01's dual chip-selects via `writeNative()`, no per-pixel work.

Tested end-to-end against 3.1.0-alpha1 on stock E1004 hardware: correct colors and orientation with no rotation needed, ~30 s wake->fetch->display cycle, battery % showing in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)