### PR TITLE
docs: E1004 confirmed on hardware; RE methodology; repo cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ settings_win.ini
 
 # Editor / IDE
 .vscode/
+
+# pi-gen clone created by os/pi/build-image.sh (an embedded git repo)
+.pigen/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ Raspberry Pi into a photo frame server without ever opening a terminal.**
 
 > **Alpha, and it means it.** Support maturity varies by screen: the
 > Hokku / Huessen frame and the Bigme F7 have been run end-to-end on real
-> hardware; the **Seeed reTerminal E1004 has never been flashed to a physical
-> device.** See [Hardware](docs/hardware.md) for per-screen status.
+> hardware for a long time; the **Seeed reTerminal E1004 has been confirmed
+> working on real hardware exactly once.** See [Hardware](docs/hardware.md) for
+> per-screen status.
 
 ---
 
@@ -123,11 +124,14 @@ A 13.3" Spectra 6 panel on a Seeed XIAO ESP32-S3. The firmware is a thin board
 layer over the shared `firmware/common/` modules, so it inherits feature parity
 with the huessen frame for free.
 
-**It has never been flashed to real hardware.** It builds against the real
-ESP-IDF toolchain in CI and passes the host test suite; the panel registers and
-pinout come from Seeed's own driver and a community Arduino port, but the
-ESP-IDF SPI/DMA plumbing and the battery divider ratio are unconfirmed on
-silicon. If you own one, reports are very welcome.
+**Confirmed working on real hardware once**
+([issue #14](https://github.com/defl/hokku_epaper/issues/14)): built with
+ESP-IDF v5.5.5, flashed over USB, then WiFi, server fetch, a correctly coloured
+and oriented photo on the panel, and battery reporting in the dashboard — which
+validates the ESP-IDF SPI/DMA plumbing and the ×2.0 battery divider. One unit,
+one session: deep sleep over days, OTA and full-discharge battery behaviour are
+still unproven, and app logs do not reach the native USB serial console. More
+reports very welcome.
 
 The panel bring-up work it is based on was contributed by
 [@TaichungLester](https://github.com/TaichungLester) in
@@ -168,7 +172,8 @@ locally and biases the crop to keep them in frame.
   rollback on a pending-verify boot, and version/build headers sent to the
   server.
 - **bigme_f7 1.2.5** — new: full custom firmware for the XR872AT.
-- **seeedstudio_e1004 1.2.1** — new, and unflashed on real hardware.
+- **seeedstudio_e1004 1.2.1** — new, and now confirmed working on real
+  hardware once ([issue #14](https://github.com/defl/hokku_epaper/issues/14)).
 
 Firmware is now built from a shared foundation: `firmware/common/all` (pure C,
 every screen), `firmware/common/esp32` (ESP-IDF) and `firmware/common/xr872`.
@@ -184,7 +189,9 @@ and `installer`. Every internal link in the repository was checked and repaired.
 
 ### Known issues and caveats
 
-- The **Seeed reTerminal E1004 is unproven on hardware** — treat it as untested.
+- The **Seeed reTerminal E1004 has one confirmed hardware run**, not a long
+  track record — treat it as experimental. Its app logs also do not reach the
+  native USB serial console; watch the panel instead.
 - The **web app has no authentication.** Anyone who can reach port 8080 can
   manage your library and frames. Fine on a trusted home network; do not expose
   it to the internet.

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -31,10 +31,11 @@ differ from the original factory firmware.
 
 **Support maturity varies sharply by model.** The Hokku / Huessen
 13.3" frame and the Bigme F7 have both been run end-to-end on real
-hardware. The **Seeed reTerminal E1004 has never been flashed to a
-physical device** — its firmware builds and passes host tests, but no
-part of it has been confirmed on silicon. Treat it as untested code,
-not a supported configuration.
+hardware over an extended period. The **Seeed reTerminal E1004 has been
+confirmed working on a physical device exactly once** — flash, WiFi,
+server fetch, panel render and battery reporting all verified in a
+single session. Longer-term behaviour (deep sleep over days, OTA,
+a full battery discharge) is still unproven. Treat it as experimental.
 
 **Before flashing, back up the factory firmware from your frame.** A
 complete flash dump can be restored if anything goes wrong, but only

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Write the [appliance image](docs/appliance.md) to a Raspberry Pi, join the WiFi 
 |---|---|---|---|
 | **Hokku / Huessen 13.3"** | 13.3" | from ~$279 | ✅ Fully supported — the original, most thoroughly tested |
 | **Bigme F7** | 7.3" | ~$99 | ✅ Supported — proven end-to-end on real hardware |
-| **Seeed reTerminal E1004** | 13.3" | ~$288 | ⚠️ Experimental — builds and passes tests, never run on real hardware |
+| **Seeed reTerminal E1004** | 13.3" | ~$288 | ⚠️ Experimental — confirmed working on real hardware once |
 
 All three use **E Ink Spectra 6**, so one photo library feeds every frame — and you can mix sizes and orientations against it. See **[Hardware](docs/hardware.md)** for where to buy and what to check.
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -10,7 +10,7 @@ photo library.
 |---|---|---|---|---|
 | [**Hokku / Huessen 13.3"**](#hokku--huessen-133) | 13.3" | from ~$279 | ESP32-S3 | ✅ Fully supported — the original, most thoroughly tested |
 | [**Bigme F7**](#bigme-f7) | 7.3" | ~$99 | XR872AT | ✅ Supported — proven end-to-end on real hardware |
-| [**Seeed reTerminal E1004**](#seeed-reterminal-e1004) | 13.3" | ~$288 | ESP32-S3 | ⚠️ Experimental — builds and passes tests, **never run on real hardware** |
+| [**Seeed reTerminal E1004**](#seeed-reterminal-e1004) | 13.3" | ~$288 | ESP32-S3 | ⚠️ Experimental — confirmed working on real hardware once |
 
 All three use **E Ink Spectra 6** — the same six-ink family (black, white, yellow,
 red, blue, green), so the same photo library and conversion pipeline serves all of
@@ -83,12 +83,16 @@ the usual marketplaces.
 
 ## Seeed reTerminal E1004
 
-> ⚠️ **Experimental — not hardware-verified.** The firmware compiles, links
-> against the real ESP-IDF toolchain in CI, and passes the host test suite, but
-> **it has never been flashed to a physical E1004.** The panel registers and
-> pinout come from Seeed's own driver and a community Arduino port; the ESP-IDF
-> SPI/DMA plumbing and the battery divider ratio are unverified on silicon. If
-> you own one, [we'd love to hear how it goes](https://github.com/defl/hokku_epaper/issues).
+> ⚠️ **Experimental — confirmed on hardware once.** A first end-to-end run on a
+> physical E1004 is confirmed
+> ([issue #14](https://github.com/defl/hokku_epaper/issues/14)): flash, WiFi,
+> server fetch, correct panel render and battery reporting all worked, so the
+> ESP-IDF SPI/DMA plumbing and the ×2.0 battery divider check out. That is one
+> unit in one session — deep sleep over days, OTA and full-discharge battery
+> behaviour are still unproven, and app logs do not reach the native USB serial
+> console (see the
+> [screen page](screens/seeedstudio_e1004/README.md#serial-console-known-issue)).
+> More reports [very welcome](https://github.com/defl/hokku_epaper/issues).
 
 A 13.3" Spectra 6 panel on a Seeed XIAO ESP32-S3, on the reTerminal E-Series
 baseboard. Same panel family and resolution as the Hokku/Huessen frame.

--- a/docs/screens/bigme_f7/reverse_engineering_overview.md
+++ b/docs/screens/bigme_f7/reverse_engineering_overview.md
@@ -23,6 +23,25 @@ See [`hardware_facts.md`](hardware_facts.md) for the hardware reference.
 - [x] **Custom firmware: reporting, config, deep-sleep, battery, A/B OTA** — all
       verified on hardware (see `custom_firmware.md`, `ota.md`)
 
+### How the BROM protocol was decoded
+
+Worth recording, because the same approach transfers to any device with a
+vendor flashing tool and an undocumented wire protocol:
+
+1. Run the **vendor tool** (PhoenixMC) against the device normally — no
+   virtual COM ports, no interception, nothing that changes its behaviour.
+2. Capture the USB traffic underneath it with **USBPcap / Wireshark**,
+   filtered to the CH340 bridge (VID `1A86:7523`).
+3. Decode the captures offline: match request/response framing, then work out
+   the checksum over known-good frames until it reproduces byte-for-byte.
+
+That produced the command set and CRC scheme now implemented directly in
+[`tools/xr872_flasher.py`](../../../tools/xr872_flasher.py) — `GetFlashId`,
+`ReadSector`, `WriteSector`, `EraseFlash`, `ChangeBaud`, `SysReboot` — which
+is why flashing an F7 needs no vendor tooling on any platform. The one-off
+capture and decode scripts served their purpose and were removed once the
+protocol was implemented and verified.
+
 ## Firmware Extraction Plan
 
 ### Option A: Direct SPI Flash Read (Recommended First Attempt)

--- a/docs/screens/seeedstudio_e1004/README.md
+++ b/docs/screens/seeedstudio_e1004/README.md
@@ -4,27 +4,29 @@ A 13.3" E Ink Spectra 6 panel (T133A01, 1200×1600) on a Seeed XIAO ESP32-S3
 mounted on the reTerminal E-Series baseboard — same panel family and resolution
 as the Hokku/Huessen frame, on open, documented hardware.
 
-> ## ⚠️ Experimental — never run on real hardware
+> ## ⚠️ Confirmed on hardware once, lightly tested
 >
-> The firmware compiles, links against the real ESP-IDF toolchain in CI, and
-> passes the host test suite. **It has never been flashed to a physical E1004.**
+> A first end-to-end run on a physical E1004 is confirmed
+> ([issue #14](https://github.com/defl/hokku_epaper/issues/14)): built with
+> ESP-IDF v5.5.5, flashed over USB, then WiFi + server fetch + a photo rendered
+> with correct colours and orientation, and the frame registered in the dashboard
+> with a sane battery reading — so the ESP-IDF SPI/DC/DMA plumbing and the ×2.0
+> battery divider both check out.
 >
-> - The panel registers and pinout come from Seeed's own `Seeed_GxEPD2` driver
->   and a community Arduino port that *was* hardware-tested.
-> - **Unverified on silicon:** the ESP-IDF SPI/DC/DMA plumbing, and the battery
->   divider ratio (GPIO1 ADC × 2.0 — see [hardware guesses](hardware_guesses.md)).
+> That is **one unit, one session** — not the long-running fleet history behind
+> the huessen frame and the Bigme F7. Deep sleep over days, OTA and battery
+> behaviour over a full discharge are still unproven.
 >
-> If you own one, please try it and
-> [tell us how it went](https://github.com/defl/hokku_epaper/issues) — that's the
-> one thing standing between this and full support.
+> **Known issue:** app logs do not reach the native USB serial console. See
+> [serial console](#serial-console-known-issue) below.
 
 ## Documentation
 
 - [Hardware facts](hardware_facts.md) — confirmed from Seeed's wiki and driver:
   SoC, panel, GPIO map, expansion header
 - [Hardware guesses](hardware_guesses.md) — inferences not yet E1004-confirmed,
-  including the battery divider and the USB-detect behaviour that does **not**
-  carry over from the huessen frame
+  including the USB-detect behaviour that does **not** carry over from the
+  huessen frame
 - [Firmware source and build](../../../firmware/seeedstudio_e1004/README.md)
 
 ## How it's built
@@ -56,3 +58,24 @@ Arduino client.
 
 The panel's native nibble encoding matches Hokku's wire format exactly, so no
 colour remapping is needed when driving it.
+
+## Serial console (known issue)
+
+The firmware is built with `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y` (the same
+setting the huessen frame uses, where it works). On the E1004, the native USB
+port shows the ROM bootloader banner and then goes **completely silent** for the
+rest of boot — no second-stage bootloader line, no app logs. Reproduced with
+both `idf.py monitor` and a raw reset-pulse capture.
+
+The device is not hung: the panel renders normally throughout, which is how the
+first hardware run was verified at all. Only the log stream is missing. The
+Arduino reference example for this board notes that diagnostic output goes out
+`Serial0` / UART0, so the likely explanation is that the console ends up on the
+physical UART0 pins rather than the USB Serial/JTAG peripheral — but that has
+not been confirmed with a probe on the header.
+
+**If you are bringing this board up, do not read silence on the USB port as a
+crash.** Watch the panel, or use the frame's own diagnostics instead: the
+firmware keeps a log ring and reports state to the server via `X-Frame-State`,
+both visible in the web app. Reported in
+[issue #14](https://github.com/defl/hokku_epaper/issues/14).

--- a/docs/screens/seeedstudio_e1004/hardware_facts.md
+++ b/docs/screens/seeedstudio_e1004/hardware_facts.md
@@ -40,7 +40,10 @@ sibling-board-derived values that are not E1004-confirmed belong in
 ## Battery voltage sense (CONFIRMED — corroborated by Seeed ESPHome cookbook + Zephyr E-Series devicetree + the community Arduino port that was hardware-tested end-to-end)
 - **ADC pin**: GPIO1 (ESP32-S3 ADC1_CH0). RTC-capable.
 - **Divider-enable pin**: GPIO21, active-HIGH — must be driven HIGH to read the battery; otherwise the divider path is disconnected. RTC-capable. Drive LOW before sleep to avoid leaking through the divider.
-- **Divider ratio**: 2.0× (10 kΩ / 10 kΩ). Vbatt = Vadc × 2.
+- **Divider ratio**: 2.0× (10 kΩ / 10 kΩ). Vbatt = Vadc × 2. Corroborated on a
+  real E1004 running this firmware — the frame reported a plausible battery %
+  in the dashboard ([issue #14](https://github.com/defl/hokku_epaper/issues/14)).
+  That is a sanity check, not a metered calibration across the discharge curve.
 - Sources: https://wiki.seeedstudio.com/reterminal_e10xx_with_esphome_advanced/ ; Zephyr `boards/seeed/reterminal_e1002` devicetree (shared baseboard).
 
 ## RTC-wake-capable GPIOs

--- a/firmware/seeedstudio_e1004/README.md
+++ b/firmware/seeedstudio_e1004/README.md
@@ -22,16 +22,30 @@ foundation, but its panel bring-up work is what this driver is based on.
 
 ## Status — read before flashing
 
-**Host-tested and CI-built (ESP-IDF), but UNFLASHED on real E1004 hardware.**
+**Confirmed on real E1004 hardware once** — see
+[issue #14](https://github.com/defl/hokku_epaper/issues/14).
+- Built with ESP-IDF v5.5.5 (`idf.py set-target esp32s3 && idf.py build`),
+  flashed over USB, provisioned with
+  `tools/hokku_config.py set --ssid ... --url ... --name ...`. WiFi connected,
+  the server fetch succeeded, and the panel rendered a photo with correct
+  colours and orientation (no rotation or mirroring needed). The frame
+  registered in the dashboard with a sane battery %, so the **×2.0 battery
+  divider** on GPIO1 and the **ESP-IDF SPI/DC/DMA plumbing** are both confirmed.
 - The shared logic is unit-tested on the host (`test/host/`) and exercised by
   huessen's suite; the whole firmware compiles + links in CI via the real
   ESP-IDF toolchain.
-- The panel register values + pinout carry the real-hardware verification of the
-  Arduino sketch from [PR #16](https://github.com/defl/hokku_epaper/pull/16).
-- **Not** hardware-confirmed: the ESP-IDF SPI/DC/DMA plumbing on real silicon,
-  and the **battery divider ratio** (GPIO1 ADC × 2.0 — see
-  [`docs/screens/seeedstudio_e1004/hardware_guesses.md`](../../docs/screens/seeedstudio_e1004/hardware_guesses.md)).
-  Do a scope/serial bring-up and confirm the divider before a fleet deployment.
+- **Still unproven:** deep sleep across days, an OTA on this board, and battery
+  behaviour over a full discharge. One unit, one session — not a track record.
+
+**Known issue — no app logs on the native USB console.** With
+`CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y` (the same setting huessen uses, where it
+works) the native USB port emits the ROM bootloader banner and then goes silent
+for the whole boot, under both `idf.py monitor` and a raw reset-pulse capture.
+The device is *not* hung — the panel renders normally. The Arduino reference
+example notes diagnostic output going out `Serial0`/UART0 on this board, so the
+console may be landing on the physical UART0 pins; unconfirmed. During bring-up,
+watch the panel and the server-side `X-Frame-State` / log ring rather than the
+USB port.
 
 **Flashing safety (root `AGENTS.md` STOP rules):** this firmware now has **A/B
 OTA with bootloader rollback** (`CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE`, ota_0/

--- a/firmware/seeedstudio_e1004/main/main.c
+++ b/firmware/seeedstudio_e1004/main/main.c
@@ -23,13 +23,19 @@
  * cross-reference in huessen's hardware_guesses.md). Panel init sequence +
  * register values are from Seeed's own GxEPD2_T133A01 driver.
  *
- * STATUS: builds in CI (ESP-IDF), host-tested, but UNFLASHED on real E1004
- * hardware. The panel register values/pinout carry the Arduino sketch's
- * real-hardware verification (clients/reterminal_e1004); the ESP-IDF plumbing
- * and the battery divider ratio are not yet hardware-confirmed. A/B OTA + the
- * early recovery via button-wake satisfy the root AGENTS.md flashing STOP rules,
- * but confirm the battery divider and do a scope/serial bring-up before relying
- * on a fleet deployment.
+ * STATUS: confirmed working on real E1004 hardware once (issue #14) — flash,
+ * WiFi, server fetch, correct panel render and battery reporting, which
+ * validates the ESP-IDF SPI/DC/DMA plumbing and the 2.0x battery divider.
+ * Deep sleep over days, OTA and full-discharge battery behaviour are still
+ * unproven, so treat this as experimental rather than fleet-ready. A/B OTA +
+ * the early recovery via button-wake satisfy the root AGENTS.md flashing STOP
+ * rules.
+ *
+ * KNOWN ISSUE: app logs do not reach the native USB console despite
+ * CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y — the ROM banner appears, then silence
+ * for the rest of boot. Possibly routed to the physical UART0 pins instead
+ * (the Arduino reference example mentions Serial0). Use the panel and the
+ * server-side X-Frame-State / log ring for bring-up diagnostics.
  */
 
 #include <string.h>

--- a/firmware/seeedstudio_e1004/sdkconfig.defaults
+++ b/firmware/seeedstudio_e1004/sdkconfig.defaults
@@ -8,7 +8,12 @@ CONFIG_IDF_TARGET="esp32s3"
 CONFIG_ESPTOOLPY_FLASHSIZE_32MB=y
 CONFIG_ESPTOOLPY_FLASHFREQ_80M=y
 
-# Console on USB Serial/JTAG (built-in USB, same as huessen_epf1301)
+# Console on USB Serial/JTAG (built-in USB, same as huessen_epf1301).
+# KNOWN ISSUE (issue #14): on real E1004 hardware this does NOT deliver app
+# logs — the native USB port shows the ROM banner and then goes silent for the
+# rest of boot, under both `idf.py monitor` and a raw reset capture. The device
+# is fine (the panel renders); the output may be landing on the physical UART0
+# pins instead. Unresolved — see the README before debugging over USB.
 CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
 
 # Partition table — A/B OTA (ota_0 / ota_1 / otadata), see partitions.csv.

--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,3 +1,9 @@
+hokku-server (4.0.1~dev.7-1) unstable; urgency=medium
+
+  * docs(seeedstudio_e1004): confirmed working on real hardware once
+
+ -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Tue, 21 Jul 2026 07:34:54 -0500
+
 hokku-server (4.0.1~dev.6-1) unstable; urgency=medium
 
   * ci: grant build-image.yml contents:write so it can attach the release asset

--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,3 +1,9 @@
+hokku-server (4.0.1~dev.8-1) unstable; urgency=medium
+
+  * docs(bigme_f7): record how the BROM protocol was decoded
+
+ -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Tue, 21 Jul 2026 07:58:32 -0500
+
 hokku-server (4.0.1~dev.7-1) unstable; urgency=medium
 
   * docs(seeedstudio_e1004): confirmed working on real hardware once

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hokku-server"
-version = "4.0.1.dev7"
+version = "4.0.1.dev8"
 description = "Spectra 6 e-ink image server for Hokku EL133UF1 display"
 requires-python = ">=3.9"
 license = {text = "GPL-3.0 (non-commercial)"}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hokku-server"
-version = "4.0.1.dev6"
+version = "4.0.1.dev7"
 description = "Spectra 6 e-ink image server for Hokku EL133UF1 display"
 requires-python = ">=3.9"
 license = {text = "GPL-3.0 (non-commercial)"}


### PR DESCRIPTION
**Seeed reTerminal E1004 — confirmed working on real hardware once** ([#14](https://github.com/defl/hokku_epaper/issues/14)). Flash, WiFi, server fetch, correct panel render and battery reporting all worked, confirming the ESP-IDF SPI/DC/DMA plumbing and the ×2.0 battery divider. Scoped honestly as one unit / one session — deep sleep over days, OTA and full-discharge behaviour still unproven, so it stays **experimental**. The status table in `docs/hardware.md` was the last place still claiming it had never run on hardware.

Also records a real known issue: app logs never reach the native USB console despite `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y` — ROM banner, then silence. Anyone bringing this board up would otherwise read that as a crash.

**Firmware VERSION deliberately unchanged** at 1.2.1 — the `main.c` / `sdkconfig.defaults` diffs are comments only, so bumping would make every deployed frame pull an OTA of a byte-identical binary.

**Repo cleanup** — removed 33 untracked F7 scratch scripts, the 15 MB `.pigen/` clone, and a stray `python/uv.lock`. Verified first that nothing unique was lost: the BROM protocol lives in `tools/xr872_flasher.py`, and `auto_flash_when_awake.py` worked around a platform_init crash that's since fixed. The one genuine gap — the USBPcap sniffing *method*, documented nowhere — is now written into the RE overview. `.pigen/` is gitignored so a broad `git add` can't pull in the embedded repo again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)