### PR TITLE
fix(seeedstudio_e1004): route console to UART0, not native USB Serial/JTAG

### DIFF
--- a/firmware/seeedstudio_e1004/sdkconfig.defaults
+++ b/firmware/seeedstudio_e1004/sdkconfig.defaults
@@ -8,8 +8,17 @@ CONFIG_IDF_TARGET="esp32s3"
 CONFIG_ESPTOOLPY_FLASHSIZE_32MB=y
 CONFIG_ESPTOOLPY_FLASHFREQ_80M=y
 
-# Console on USB Serial/JTAG (built-in USB, same as huessen_epf1301)
-CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+# Console on UART0 — NOT the same as huessen_epf1301. On this baseboard the
+# USB-C port is wired through an external CH340K bridge to UART0 (GPIO43/44),
+# not to the SoC's native USB Serial/JTAG peripheral: Windows enumerates the
+# device as VID_1A86:PID_7522 (CH340K), never as VID_303A:PID_1001 (native
+# USJ). CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y was copied from huessen_epf1301
+# without re-verifying this board's physical wiring, and silently routed the
+# app console to a peripheral with no path to the host — the ROM banner still
+# appeared because ROM boot messages print to UART0 unconditionally,
+# independent of this setting, which made it look like a live-then-silent USB
+# connection instead of a console pointed at the wrong peripheral entirely.
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
 
 # Partition table — A/B OTA (ota_0 / ota_1 / otadata), see partitions.csv.
 CONFIG_PARTITION_TABLE_CUSTOM=y


### PR DESCRIPTION
Follow-up on the diagnostic plan in #14 - ran Step 1 and it gave a clean answer, just not one of the two the table anticipated.

**Step 1 result:** `Get-PnpDevice -Class Ports` shows COM10 as `USB\VID_1A86&PID_7522` (CH340K) with `Status: OK`. There is no live `VID_303A&PID_1001` (native USB Serial/JTAG) device on the system at all - it only shows up as a stale/cached PnP entry (`Status: Unknown`) from some earlier session, not the E1004.

So this board's USB-C port routes through an external CH340K bridge wired to UART0, not to the SoC's native USB Serial/JTAG peripheral. `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y` was silently sending the app console to a peripheral with no physical path to the host. The ROM banner still showed up over COM10 because ROM boot messages print to UART0 unconditionally, independent of this setting - which is exactly what made a misrouted console look like "USB alive, then silent" instead of what it actually was.

Fixed in the linked PR (one line: `CONFIG_ESP_CONSOLE_UART_DEFAULT=y` instead of `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y`) and verified on the real unit - full boot log now visible over COM10:

```
I (822) cpu_start: GPIO 44 and 43 are used as console UART I/O pins
...
I (308) octal_psram: vendor id    : 0x0d (AP)
I (352) esp_psram: Found 8MB PSRAM device
I (355) esp_psram: Speed: 80MHz
...
I (937) e1004: Firmware 1.2.1 built 20260721130425Z
I (1007) e1004: battery: pin=2079 mV -> 4158 mV
...
I (1647) wifi:connected with Lester, aid = 38, channel 4, BW20, bssid = ba:c5:99:6a:37:39
I (1647) wifi:security: WPA3-SAE H2E, phy: bgn, rssi: -43, cipher(pairwise:0x3, group:0x3), pmf:1
...
I (1687) hokku: Got IP: 192.168.50.124
E (1797) HTTP_HEADER: Buffer length is small to fit all the headers
I (2947) hokku: X-Sleep-Seconds: 35440
I (2947) hokku: Downloaded 960000 bytes
...
I (4367) e1004: DRF - refreshing (~30-40s)...
I (30917) e1004: DRF done (26549ms)
I (31027) e1004: refresh done; next in 35440 s
I (31027) e1004: Deep sleep 35412 s (next_ep=1784674799)
```

Full boot-to-sleep cycle in ~31s. Battery reads 4158mV at what should be near-full charge - consistent with the ×2.0 divider guess in `hardware_guesses.md`, so that one can probably be marked confirmed too.

One thing worth a look separately: `E (1797) HTTP_HEADER: Buffer length is small to fit all the headers` fires every run but doesn't seem to block the download (`Downloaded 960000 bytes` follows right after) - flagging it since it's an ERROR-level log on an otherwise-successful path, not something I'm confident is harmless just because it didn't crash this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
