### PR TITLE
fix(server): guard against near-immediate double refresh on clock drift

### DIFF
--- a/python/hokku/webserver/time_utils.py
+++ b/python/hokku/webserver/time_utils.py
@@ -11,6 +11,15 @@ from hokku.webserver.app_config import AppConfig
 
 DEBUG_FAST_REFRESH_SECONDS = 180
 
+# A device's deep-sleep timer (ESP32 internal RC oscillator) can drift by
+# several minutes over a long sleep, waking it a bit early. If we naively
+# scheduled the next wake at the nearest future slot, an early wake this
+# close to that slot would get told to sleep only a few minutes, wake again
+# right at the nominal slot, and serve a second refresh almost immediately.
+# Slots within this window of "now" are treated as already served by the
+# current request, so we skip ahead to the following slot instead.
+MIN_SLOT_GAP_SECONDS = 900  # 15 minutes
+
 
 def calculate_sleep_seconds(config: AppConfig) -> int:
     """Seconds until the next configured refresh time (system local TZ).
@@ -34,10 +43,10 @@ def calculate_sleep_seconds(config: AppConfig) -> int:
 
     for h, m in wake_times:
         candidate = now.replace(hour=h, minute=m, second=0, microsecond=0)
-        if candidate > now:
+        if (candidate - now).total_seconds() > MIN_SLOT_GAP_SECONDS:
             return max(60, int((candidate - now).total_seconds()))
 
-    # All today's slots are past — use tomorrow's first slot.
+    # Remaining today's slots are past or imminent — use tomorrow's first slot.
     h, m = wake_times[0]
     tomorrow = now + timedelta(days=1)
     candidate = tomorrow.replace(hour=h, minute=m, second=0, microsecond=0)

--- a/python/tests/test_time_utils.py
+++ b/python/tests/test_time_utils.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from hokku.webserver.app_config import AppConfig
 from hokku.webserver.time_utils import (
     DEBUG_FAST_REFRESH_SECONDS,
+    MIN_SLOT_GAP_SECONDS,
     calculate_sleep_seconds,
     format_duration_human,
 )
@@ -93,6 +94,32 @@ def test_multiple_slots_picks_nearest_future():
         mock_dt.now.return_value = now
         result = calculate_sleep_seconds(cfg)
     assert 7_000 <= result <= 7_300, f"Expected ~7200 s, got {result}"
+
+
+def test_imminent_slot_skipped_to_avoid_double_refresh():
+    """A device whose deep-sleep timer drifted can wake a few minutes before
+    its nominal slot. That wake already serves the slot, so the next slot
+    within MIN_SLOT_GAP_SECONDS must be skipped rather than returning a very
+    short sleep that would wake the device again almost immediately."""
+    # now=18:52, slots at 07:00/19:00 → 19:00 is only 8 min away (imminent),
+    # so it should be skipped in favour of tomorrow's 07:00 (~12h08m).
+    now = _fake_now(18, 52)
+    cfg = _cfg(debug_fast_refresh=False, refresh_image_at_time=["0700", "1900"])
+    with patch("hokku.webserver.time_utils.datetime") as mock_dt:
+        mock_dt.now.return_value = now
+        result = calculate_sleep_seconds(cfg)
+    assert result > MIN_SLOT_GAP_SECONDS
+    assert 43_500 <= result <= 43_700, f"Expected ~12h08m, got {result}"
+
+
+def test_slot_just_outside_min_gap_still_chosen():
+    """A slot just beyond MIN_SLOT_GAP_SECONDS away is still picked normally."""
+    now = _fake_now(18, 44)  # 19:00 is 16 min away, past the 15 min guard
+    cfg = _cfg(debug_fast_refresh=False, refresh_image_at_time=["0700", "1900"])
+    with patch("hokku.webserver.time_utils.datetime") as mock_dt:
+        mock_dt.now.return_value = now
+        result = calculate_sleep_seconds(cfg)
+    assert 900 <= result <= 1_000, f"Expected ~16 min, got {result}"
 
 
 # ── format_duration_human ─────────────────────────────────────────────────────


### PR DESCRIPTION
Observed on an E1004 running long (~12h) deep-sleep intervals: the same slot's image refreshed twice in quick succession (18:50-ish, then again at 19:00).

Root cause: `calculate_sleep_seconds()` schedules the next wake as `candidate > now` for the nearest configured slot. ESP32 deep sleep runs on the internal RC oscillator, which can drift by several minutes over a long sleep and wake the device a little early. When that happens close to a scheduled slot, the check still treats the slot as strictly in the future, so it returns a sleep of only a couple of minutes - the device wakes again right at the nominal slot and serves a second refresh almost immediately after the first.

Fix: a slot within `MIN_SLOT_GAP_SECONDS` (15 min) of "now" is treated as already served by the current wake and skipped in favor of the following slot.

Added two tests: an imminent slot (8 min out) gets skipped in favor of tomorrow's first slot, and a slot just past the 15-minute guard (16 min out) is still picked normally. Ran the full host suite locally: 701 passed, 5 skipped, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
