### PR TITLE
fix(server): package templates/ and static/ with the hokku-server wheel

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,7 +45,12 @@ where = ["."]
 include = ["hokku*"]
 
 [tool.setuptools.package-data]
-"hokku.webserver" = ["models/ATTRIBUTION.md", "models/face_detection_yunet_2023mar.onnx"]
+"hokku.webserver" = [
+    "models/ATTRIBUTION.md",
+    "models/face_detection_yunet_2023mar.onnx",
+    "templates/*",
+    "static/**/*",
+]
 
 [tool.pytest.ini_options]
 addopts = ["-m", "not time_intensive and not serial", "-n", "8", "--dist=loadfile"]


### PR DESCRIPTION
`[tool.setuptools.package-data]` for `hokku.webserver` only lists the face-detection model files - `templates/` and `static/` aren't declared, so they're silently dropped from the built wheel.

This doesn't show up when running from a source checkout (Flask's relative template/static lookup happens to hit the live tree either way), but it bites anyone who does a plain `pip install` of this package: the server starts, config loads fine, `/hokku/screen/` keeps serving images to frames - but the moment you load the dashboard, it 500s:

```
jinja2.exceptions.TemplateNotFound: index.html
```

Ran into this rebuilding the server as a proper installed package (containerizing it via `pip install .` rather than copying the source tree wholesale). Confirmed the failure with a real HTTP 500 on `/hokku/ui`, added `templates/*` and `static/**/*` to package-data, rebuilt, got a 200 on the same route, and it's now serving real production traffic without issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
