### PR TITLE
perf(render): decode-once + memory-bounded decode admission

### DIFF
--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,3 +1,14 @@
+hokku-server (4.0.1~dev.14-1) unstable; urgency=medium
+
+  * perf(render): decode each source once per image (decode-once, dither-many)
+    instead of once per rendered (model, orientation) variant, and add a
+    memory-bounded decode admission semaphore so ordinary JPEG/PNG uploads decode
+    concurrently up to what the budget allows while native codecs (HEIF/AVIF/JXL)
+    stay serialized for thread-safety. Single-worker boxes (the appliance) are
+    unchanged; the budget's one-decode-at-a-time invariant is preserved.
+
+ -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Sun, 26 Jul 2026 21:36:48 +0000
+
 hokku-server (4.0.1~dev.13-1) unstable; urgency=medium
 
   * Firmware library: optionally download firmware from GitHub Releases and pin a

--- a/python/hokku/webserver/app_state.py
+++ b/python/hokku/webserver/app_state.py
@@ -44,6 +44,7 @@ def build_manager(
     """
     budget = compute_budget(config.memory_budget_mb)
     image_renderer.set_decode_budget_pixels(budget.decode_budget_pixels)
+    image_renderer.set_decode_concurrency(budget.decode_slots)
     logger.info("%s", budget.log_line())
     if budget.under_provisioned:
         logger.warning(

--- a/python/hokku/webserver/image_abc.py
+++ b/python/hokku/webserver/image_abc.py
@@ -400,8 +400,17 @@ class AbstractImageRenderer(ABC):
         crop_to_fill_threshold: float = 0.0,
         clahe_keepout_bboxes_norm: tuple[BoundingBox, ...] | None = None,
         crop_anchor_bboxes_norm: tuple[BoundingBox, ...] | None = None,
+        *,
+        release_input: bool = True,
     ) -> bytes:
-        """Full-resolution panel → wire bytes."""
+        """Full-resolution panel → wire bytes.
+
+        ``release_input=True`` (default) closes ``img`` once it has been scaled,
+        freeing the source buffer before the dither — the right choice for a
+        one-shot render. Pass ``release_input=False`` to keep ``img`` alive so the
+        same decoded source can drive several renders (decode-once, dither-many);
+        the caller then owns closing it.
+        """
         idx = self.render_indices(
             img,
             cfg,
@@ -409,7 +418,7 @@ class AbstractImageRenderer(ABC):
             self._display.panel_w,
             self._display.panel_h,
             crop_to_fill_threshold,
-            release_input=True,
+            release_input=release_input,
             clahe_keepout_bboxes_norm=clahe_keepout_bboxes_norm,
             crop_anchor_bboxes_norm=crop_anchor_bboxes_norm,
         )

--- a/python/hokku/webserver/image_manager_abstract.py
+++ b/python/hokku/webserver/image_manager_abstract.py
@@ -6,8 +6,8 @@ The single source of truth for what's known to ImageManager is
 ``<cache_dir>/image_manager.json``.
 
 Concrete subclasses (SingleThreadedImageManager, MultiThreadedImageManager)
-implement ``_dispatch_render`` and ``resolved_worker_count`` — everything
-else is shared logic and lives here.
+implement ``_run_batch`` and ``resolved_worker_count`` — everything else,
+including per-variant result routing, is shared logic and lives here.
 """
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ import shutil
 import threading
 import time
 from abc import ABC, abstractmethod
-from dataclasses import asdict, replace
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 
 import defusedxml.ElementTree as ET
@@ -64,6 +64,23 @@ _THUMB_MAX_PX = 300
 _THUMB_QUALITY = 85
 
 _KNOWN_SUFFIXES = (_PANEL_SUFFIX, _PREVIEW_SUFFIX, _THUMB_SUFFIX)
+
+
+@dataclass
+class _RenderVariant:
+    """One (model, orientation) render pending in an image's decode-once batch.
+
+    ``worker_payload`` is the plain-dict form handed to
+    ``render_worker.render_image_variants``; the other fields are what the
+    manager needs to route the result back through ``_on_render_done`` — exactly
+    as if this variant had been dispatched on its own.
+    """
+
+    slug: str
+    model: str
+    orientation: Orientation
+    update_status: bool
+    worker_payload: dict
 
 
 def _decision_to_screen_image_config(
@@ -127,24 +144,16 @@ class AbstractImageManager(ABC):
         """How many parallel renders this manager can run. 1 = serial."""
 
     @abstractmethod
-    def _dispatch_render(
-        self,
-        name: str,
-        expected_slug: str,
-        model: str,
-        orientation: Orientation,
-        render_args: tuple,
-        t0: float,
-        *,
-        update_status: bool = True,
-    ) -> None:
-        """Run ``render_one(*render_args)`` and arrange for ``_on_render_done``
-        to be called with the future when it completes.
+    def _run_batch(self, image_path: str, worker_variants: list[dict]) -> concurrent.futures.Future:
+        """Decode ``image_path`` once and render every variant in
+        ``worker_variants`` (see ``render_worker.render_image_variants``).
 
-        ``update_status=True`` (default): the primary lifecycle render — sets
-        convert_status to "ok"/"failed" and updates _progress.
-        ``update_status=False``: a secondary orientation render — only writes
-        the panel/preview files and updates the matching slug in the record.
+        Returns a Future that resolves to the per-variant results list, or raises
+        if the source could not be decoded. Multi-threaded managers submit to
+        their pool; the single-threaded manager runs inline and returns an
+        already-resolved Future. Result routing (per-variant ``_on_render_done``,
+        primary vs secondary lifecycle) is shared in ``_submit_image_batch`` — a
+        concrete manager only has to say *where* the batch runs.
         """
 
     # ── lifecycle ────────────────────────────────────────────────
@@ -944,63 +953,145 @@ class AbstractImageManager(ABC):
             # primary — it drives pending → ok and the progress counter. All
             # others are secondary (update_status=False). No model is
             # hardcoded; only the ordering is deterministic.
+            #
+            # Every uncached variant of THIS image goes into one decode-once
+            # batch: the source is decoded a single time and every (model,
+            # orientation) is dithered off that one buffer (see
+            # render_worker.render_image_variants). Cached variants are resolved
+            # inline here and never reach the batch.
             with self._db_lock:
                 sorted_models = sorted(self._known_models)
             primary_model = sorted_models[0]
+            variants: list[_RenderVariant] = []
             for mdl in sorted_models:
                 landscape_cfg = _decision_to_screen_image_config(
                     decision, Orientation.LANDSCAPE, mdl
                 )
                 portrait_cfg = _decision_to_screen_image_config(decision, Orientation.PORTRAIT, mdl)
-                self._dispatch_cfg(name, landscape_cfg, update_status=(mdl == primary_model))
-                self._dispatch_cfg(name, portrait_cfg, update_status=False)
+                v_land = self._prepare_variant(
+                    name, landscape_cfg, update_status=(mdl == primary_model)
+                )
+                v_port = self._prepare_variant(name, portrait_cfg, update_status=False)
+                variants.extend(v for v in (v_land, v_port) if v is not None)
+            if variants:
+                self._submit_image_batch(name, variants, time.monotonic())
         except Exception as e:
             err = f"{type(e).__name__}: {e}"
             logger.exception("Failed to submit %r: %s", name, err)
             self._mark_as_failed(name, err)
 
-    def _dispatch_cfg(self, name: str, cfg: ScreenImageConfig, *, update_status: bool) -> None:
-        """File-check then dispatch one (image, orientation) render job.
+    def _prepare_variant(
+        self, name: str, cfg: ScreenImageConfig, *, update_status: bool
+    ) -> _RenderVariant | None:
+        """Resolve one (image, model, orientation) into a pending render variant.
 
-        If the panel file for this cfg's slug already exists the orientation
-        slug is recorded in the DB and no render is dispatched.
-        ``update_status=True`` drives the primary lifecycle (pending → ok,
-        progress counter); ``update_status=False`` only writes files and
-        updates the orientation slug.
+        If the panel for this cfg's slug is already cached, records the orientation
+        slug (and, when ``update_status``, completes the primary lifecycle — the
+        cached primary never dispatches a render, so the counter would otherwise
+        wedge) and returns ``None``: nothing to render. Otherwise returns the
+        :class:`_RenderVariant` to include in the image's decode-once batch.
         """
         with self._db_lock:
             rec = self._records.get(name)
         if rec is None:
-            return
+            return None
         slug = cfg.cache_slug()
         if self._panel_path(rec.name_hash, slug).exists():
             self._set_orientation_slug(name, cfg.screen_model, cfg.orientation, slug)
             if update_status:
-                # The primary render is already cached (no render dispatched), so
-                # _on_render_done won't run for it — complete the lifecycle here or
-                # the image stays 'pending'/in-flight and the progress counter wedges.
                 self._complete_cached_primary(name)
-            return
-        render_args = (
-            str(self._upload_dir / name),
-            asdict(cfg.image_config),
-            cfg.screen_model,
-            cfg.orientation,
-            cfg.crop_to_fill_threshold,
-            tuple(asdict(b) for b in cfg.clahe_keepout_bboxes)
+            return None
+        payload = {
+            "model": cfg.screen_model,
+            "orientation": cfg.orientation.value,
+            "image_config": asdict(cfg.image_config),
+            "crop_to_fill_threshold": cfg.crop_to_fill_threshold,
+            "clahe_keepout_bboxes": tuple(asdict(b) for b in cfg.clahe_keepout_bboxes)
             if cfg.clahe_keepout_bboxes
             else None,
-            tuple(asdict(b) for b in cfg.face_crop_bboxes) if cfg.face_crop_bboxes else None,
-        )
-        logger.debug("Submitted %r for dithering (%s, %s)", name, cfg.screen_model, cfg.orientation)
-        self._dispatch_render(
-            name,
-            slug,
-            cfg.screen_model,
-            cfg.orientation,
-            render_args,
-            time.monotonic(),
+            "face_crop_bboxes": tuple(asdict(b) for b in cfg.face_crop_bboxes)
+            if cfg.face_crop_bboxes
+            else None,
+        }
+        return _RenderVariant(
+            slug=slug,
+            model=cfg.screen_model,
+            orientation=cfg.orientation,
             update_status=update_status,
+            worker_payload=payload,
+        )
+
+    def _submit_image_batch(self, name: str, variants: list[_RenderVariant], t0: float) -> None:
+        """Dispatch one decode-once batch for ``name`` and, on completion, route
+        each variant through :meth:`_on_render_done`.
+
+        The whole per-variant lifecycle (primary vs secondary, cache-file writes,
+        failure handling) is byte-for-byte the same as when every variant was
+        dispatched separately — each variant still gets its own resolved Future
+        and its own ``_on_render_done`` call. The only change is that the source
+        is decoded once for the batch instead of once per variant.
+        """
+        image_path = str(self._upload_dir / name)
+        worker_variants = [v.worker_payload for v in variants]
+        logger.debug("Submitted %r for dithering (%d variant(s))", name, len(variants))
+        batch_future = self._run_batch(image_path, worker_variants)
+        batch_future.add_done_callback(
+            lambda bf, _n=name, _v=variants, _t=t0: self._fan_out_batch(_n, _v, bf, _t)
+        )
+
+    def _fan_out_batch(
+        self,
+        name: str,
+        variants: list[_RenderVariant],
+        batch_future: concurrent.futures.Future,
+        t0: float,
+    ) -> None:
+        """Deliver each variant's result to ``_on_render_done``.
+
+        A whole-batch failure means the source could not be decoded — that dooms
+        every variant, so each is failed with the decode exception. Otherwise each
+        variant is delivered with its own success/failure from the results list.
+        """
+        try:
+            results = batch_future.result()
+        except Exception as decode_exc:  # a decode failure dooms every variant
+            for variant in variants:
+                self._deliver_variant(name, variant, None, decode_exc, t0)
+            return
+        for variant, res in zip(variants, results):
+            if res.get("ok"):
+                self._deliver_variant(
+                    name, variant, (res["panel_bytes"], res["preview_bytes"]), None, t0
+                )
+            else:
+                self._deliver_variant(
+                    name, variant, None, RuntimeError(res.get("error") or "render failed"), t0
+                )
+
+    def _deliver_variant(
+        self,
+        name: str,
+        variant: _RenderVariant,
+        result: tuple[bytes, bytes] | None,
+        exc: BaseException | None,
+        t0: float,
+    ) -> None:
+        """Wrap one variant's outcome in a resolved Future and hand it to
+        ``_on_render_done`` — exactly the shape that method saw when each variant
+        was its own executor job."""
+        future: concurrent.futures.Future = concurrent.futures.Future()
+        if exc is not None:
+            future.set_exception(exc)
+        else:
+            future.set_result(result)
+        self._on_render_done(
+            name,
+            variant.slug,
+            variant.model,
+            variant.orientation,
+            future,
+            t0,
+            update_status=variant.update_status,
         )
 
     def _set_orientation_slug(
@@ -1048,9 +1139,10 @@ class AbstractImageManager(ABC):
     ) -> None:
         """Called when a render finishes.
 
-        For multi-threaded managers this runs on a worker thread (via
-        ``Future.add_done_callback``). For single-threaded managers this is
-        invoked synchronously from ``_dispatch_render`` on the calling thread.
+        For multi-threaded managers this runs on a worker thread (via the batch
+        ``Future.add_done_callback`` → ``_fan_out_batch``). For single-threaded
+        managers the batch Future is already resolved, so this runs synchronously
+        on the calling thread.
         """
         try:
             panel_bytes, preview_bytes = future.result()

--- a/python/hokku/webserver/image_manager_multi.py
+++ b/python/hokku/webserver/image_manager_multi.py
@@ -1,8 +1,9 @@
 """MultiThreadedImageManager: renders on a private ThreadPoolExecutor.
 
-Single process; GIL-bound while the dither hot path is pure Python.
-Switching to a GIL-releasing implementation later requires no callsite
-changes — threading already gives parallelism for free at that point.
+Single process, so all render threads share one address space (and one RAM
+budget). The numba dither releases the GIL, so concurrent renders make real
+CPU progress; a batch decodes its source once and dithers every variant off
+that one buffer.
 """
 
 from __future__ import annotations
@@ -11,8 +12,7 @@ import concurrent.futures
 
 from hokku.webserver.app_config import AppConfig
 from hokku.webserver.image_manager_abstract import AbstractImageManager
-from hokku.webserver.orientation import Orientation
-from hokku.webserver.render_worker import render_one
+from hokku.webserver.render_worker import render_image_variants
 
 
 class MultiThreadedImageManager(AbstractImageManager):
@@ -37,23 +37,11 @@ class MultiThreadedImageManager(AbstractImageManager):
     def resolved_worker_count(self) -> int:
         return self._worker_count
 
-    def _dispatch_render(
-        self,
-        name: str,
-        expected_slug: str,
-        model: str,
-        orientation: Orientation,
-        render_args: tuple,
-        t0: float,
-        *,
-        update_status: bool = True,
-    ) -> None:
-        future = self._executor.submit(render_one, *render_args)
-        future.add_done_callback(
-            lambda f, _n=name, _s=expected_slug, _m=model, _o=orientation, _t=t0, _us=update_status: (
-                self._on_render_done(_n, _s, _m, _o, f, _t, update_status=_us)
-            )
-        )
+    def _run_batch(self, image_path: str, worker_variants: list[dict]) -> concurrent.futures.Future:
+        # One executor job per image: decode once, dither every variant. Different
+        # images run concurrently across the pool; result routing happens in the
+        # shared _submit_image_batch done-callback.
+        return self._executor.submit(render_image_variants, image_path, worker_variants)
 
     def shutdown(self) -> None:
         self._executor.shutdown(wait=False)

--- a/python/hokku/webserver/image_manager_single.py
+++ b/python/hokku/webserver/image_manager_single.py
@@ -11,8 +11,7 @@ from __future__ import annotations
 import concurrent.futures
 
 from hokku.webserver.image_manager_abstract import AbstractImageManager
-from hokku.webserver.orientation import Orientation
-from hokku.webserver.render_worker import render_one
+from hokku.webserver.render_worker import render_image_variants
 
 
 class SingleThreadedImageManager(AbstractImageManager):
@@ -22,22 +21,13 @@ class SingleThreadedImageManager(AbstractImageManager):
     def resolved_worker_count(self) -> int:
         return 1
 
-    def _dispatch_render(
-        self,
-        name: str,
-        expected_slug: str,
-        model: str,
-        orientation: Orientation,
-        render_args: tuple,
-        t0: float,
-        *,
-        update_status: bool = True,
-    ) -> None:
+    def _run_batch(self, image_path: str, worker_variants: list[dict]) -> concurrent.futures.Future:
+        # Run the whole decode-once batch inline on the calling thread and return
+        # an already-resolved Future; the shared _submit_image_batch callback then
+        # fires synchronously, so sync() stays fully serial with no worker thread.
         future: concurrent.futures.Future = concurrent.futures.Future()
         try:
-            future.set_result(render_one(*render_args))
-        except BaseException as e:
+            future.set_result(render_image_variants(image_path, worker_variants))
+        except BaseException as e:  # mirror onto the Future for uniform routing
             future.set_exception(e)
-        self._on_render_done(
-            name, expected_slug, model, orientation, future, t0, update_status=update_status
-        )
+        return future

--- a/python/hokku/webserver/image_renderer.py
+++ b/python/hokku/webserver/image_renderer.py
@@ -173,31 +173,56 @@ def _rasterize_svg(path: Path) -> Image.Image:
     return Image.open(io.BytesIO(png_bytes)).convert("RGB")
 
 
-# Image DECODING is serialized across render threads by this GLOBAL lock — every
-# format takes it, at most one decode is ever in flight. Two reasons:
-#   1. libheif (via pillow_heif, HEIF/HEIC) is not thread-safe: two workers
-#      decoding HEIF at once deadlock/stall.
-#   2. The memory budget (resource_budget.resolve_worker_count) sizes the worker
-#      count as "baseline + ONE worst-case decode + N lighter post-decode renders".
-#      That reservation of a SINGLE decode peak is only safe while this lock keeps
-#      decodes serialized; letting common formats (JPEG/PNG) decode concurrently
-#      would allow N simultaneous decodes and blow the budget on multi-worker
-#      boxes. Scoping the lock to just the native codecs is therefore deferred
-#      until the budget layer can reserve for concurrent decodes (a decode
-#      admission semaphore) rather than assuming one at a time.
-# Serializing the decode is cheap; the parallel win is the numba dither downstream
-# (render_panel_bytes), which runs unlocked — and with decode-once each source is
-# now decoded a single time per image, not once per rendered variant.
-_DECODE_LOCK = threading.Lock()
+# Image DECODING is bounded across render threads two independent ways:
+#
+#   1. MEMORY — every decode (any format) takes a permit from _DECODE_SEMAPHORE,
+#      whose size is derived from the memory budget (see
+#      resource_budget.resolve_decode_concurrency) and installed via
+#      set_decode_concurrency(). At most K decodes are ever in flight, and the
+#      budget picks K so K*decode_peak stays within RAM. K=1 (a 1-worker box like
+#      the Pi) fully serializes decode — identical to the old global lock; K>1
+#      lets ordinary JPEG/PNG uploads decode in parallel instead of queuing behind
+#      one decode, without risking OOM on multi-worker boxes.
+#
+#   2. THREAD-SAFETY — the native container codecs in _NATIVE_DECODE_SUFFIXES are
+#      not safe to run concurrently with themselves: libheif (pillow_heif,
+#      HEIF/HEIC) deadlocks/stalls two-at-a-time (the reason multi-render hung on
+#      .heic/.heif sets); libavif (AVIF) and libjxl (JXL) are kept here
+#      conservatively. Those formats additionally take _NATIVE_DECODE_LOCK, so at
+#      most one native decode runs at a time regardless of K.
+#
+# Acquisition order is always semaphore → native lock, so the two never deadlock.
+# The parallel win downstream (the numba dither in render_panel_bytes) runs
+# unlocked; with decode-once each source is decoded a single time per image.
+_NATIVE_DECODE_SUFFIXES = frozenset({".heic", ".heif", ".hif", ".avif", ".jxl"})
+_NATIVE_DECODE_LOCK = threading.Lock()
+_DECODE_SEMAPHORE = threading.BoundedSemaphore(1)
+
+
+def set_decode_concurrency(max_concurrent_decodes: int) -> None:
+    """Install how many source decodes may run at once (see
+    resource_budget.resolve_decode_concurrency).
+
+    Called once at startup and on every config reload. ``open_image_for_render``
+    reads this module global at ``with`` time, so a reload takes effect for the
+    next decode. Always at least 1.
+    """
+    global _DECODE_SEMAPHORE
+    _DECODE_SEMAPHORE = threading.BoundedSemaphore(max(1, int(max_concurrent_decodes)))
 
 
 def open_image_for_render(path: Path) -> Image.Image:
     """PIL.open + EXIF transpose + RGB convert + size cap.  Caller closes.
 
-    Serialized via :data:`_DECODE_LOCK` (see above); the returned image is fully
-    decoded, so downstream rendering still parallelises.
+    Bounded by :data:`_DECODE_SEMAPHORE` (concurrent-decode memory) and, for the
+    native codecs in :data:`_NATIVE_DECODE_SUFFIXES`, :data:`_NATIVE_DECODE_LOCK`
+    (their decoders are not thread-safe). The returned image is fully decoded, so
+    downstream rendering still parallelises regardless.
     """
-    with _DECODE_LOCK:
+    with _DECODE_SEMAPHORE:
+        if path.suffix.lower() in _NATIVE_DECODE_SUFFIXES:
+            with _NATIVE_DECODE_LOCK:
+                return _open_image_for_render(path)
         return _open_image_for_render(path)
 
 

--- a/python/hokku/webserver/image_renderer.py
+++ b/python/hokku/webserver/image_renderer.py
@@ -173,11 +173,21 @@ def _rasterize_svg(path: Path) -> Image.Image:
     return Image.open(io.BytesIO(png_bytes)).convert("RGB")
 
 
-# Image DECODING is serialized across render threads. libheif (via pillow_heif,
-# for HEIF/HEIC) is not thread-safe: two workers decoding HEIF images at once
-# deadlock/stall — the reason the MultiThreadedImageManager appeared to hang on
-# image sets containing .heic/.heif. Serializing the decode is cheap; the parallel
-# win is the numba dither downstream (render_panel_bytes), which runs unlocked.
+# Image DECODING is serialized across render threads by this GLOBAL lock — every
+# format takes it, at most one decode is ever in flight. Two reasons:
+#   1. libheif (via pillow_heif, HEIF/HEIC) is not thread-safe: two workers
+#      decoding HEIF at once deadlock/stall.
+#   2. The memory budget (resource_budget.resolve_worker_count) sizes the worker
+#      count as "baseline + ONE worst-case decode + N lighter post-decode renders".
+#      That reservation of a SINGLE decode peak is only safe while this lock keeps
+#      decodes serialized; letting common formats (JPEG/PNG) decode concurrently
+#      would allow N simultaneous decodes and blow the budget on multi-worker
+#      boxes. Scoping the lock to just the native codecs is therefore deferred
+#      until the budget layer can reserve for concurrent decodes (a decode
+#      admission semaphore) rather than assuming one at a time.
+# Serializing the decode is cheap; the parallel win is the numba dither downstream
+# (render_panel_bytes), which runs unlocked — and with decode-once each source is
+# now decoded a single time per image, not once per rendered variant.
 _DECODE_LOCK = threading.Lock()
 
 

--- a/python/hokku/webserver/render_worker.py
+++ b/python/hokku/webserver/render_worker.py
@@ -1,4 +1,4 @@
-"""Top-level worker function submitted to the ProcessPoolExecutor.
+"""Top-level worker function submitted to the render executor.
 
 Must be a module-level (picklable) callable.  All imports are done inside
 the function body so they happen in the worker process, not in the parent
@@ -6,9 +6,18 @@ at import time — this avoids pickling large objects across the IPC boundary.
 
 Public interface
 ----------------
-render_one(image_path, image_config_dict, orientation, crop_to_fill_threshold,
-           clahe_keepout_bboxes, face_crop_bboxes)
-    → (panel_bytes: bytes, preview_bytes: bytes)
+render_image_variants(image_path, variants)
+    → list[dict], one entry per variant (aligned with the input order):
+      {"ok": True, "panel_bytes": bytes, "preview_bytes": bytes} on success, or
+      {"ok": False, "error": str} if that single variant's render raised.
+    The source is DECODED ONCE and every variant is rendered off that one
+    buffer (decode-once, dither-many).  A failure to *decode* the source raises
+    out of the call — it dooms every variant, so the caller fails the whole
+    image once instead of per variant.
+
+render_one(image_path, image_config_dict, model, orientation, ...)
+    → (panel_bytes, preview_bytes) — thin single-variant wrapper over
+      render_image_variants, kept for callers/tests that want one output.
 
 Why dicts, not dataclasses?
     The dataclasses are picklable *today*, but any future refactor that adds a
@@ -20,50 +29,38 @@ Why dicts, not dataclasses?
 from __future__ import annotations
 
 
-def render_one(
-    image_path: str,
-    image_config_dict: dict,
-    model: str,
-    orientation: str,
-    crop_to_fill_threshold: float = 0.0,
-    clahe_keepout_bboxes: tuple[dict, ...] | None = None,
-    face_crop_bboxes: tuple[dict, ...] | None = None,
-) -> tuple[bytes, bytes]:
-    """Render one image inside a worker process.
+def render_image_variants(image_path: str, variants: list[dict]) -> list[dict]:
+    """Decode ``image_path`` once, then render every variant off that one buffer.
 
     Parameters
     ----------
     image_path:
         Absolute path to the source image file.
-    image_config_dict:
-        ``dataclasses.asdict(image_config)`` — the full ImageConfig as a plain
-        dict, ready to be reconstructed via ``_image_config_from_dict``.
-    model:
-        Screen model id (e.g. ``"huessen_epf1301"``, ``"bigme_f7"``) selecting
-        the ``Display`` that drives palette, geometry, and wire packing.
-    orientation:
-        ``"landscape"`` or ``"portrait"``.
-    crop_to_fill_threshold:
-        Passed through to ``render_panel_bytes``; controls when the image is
-        cropped to fill the panel (0.0 = never crop, always letterbox).
-    clahe_keepout_bboxes:
-        BoundingBox instances as dicts (asdict result) of detected faces,
-        or None.  Passed to the renderer to scope CLAHE away from the faces.
-    face_crop_bboxes:
-        BoundingBox instances as dicts (asdict result) of detected faces,
-        or None.  When set, the cover-crop window is centered on the union of
-        these faces instead of the image center ("face-aware cropping").
+    variants:
+        One dict per (model, orientation) render to produce.  Each carries:
+        ``model`` (screen id), ``orientation`` ("landscape"/"portrait"),
+        ``image_config`` (``dataclasses.asdict(image_config)``),
+        ``crop_to_fill_threshold`` (float),
+        ``clahe_keepout_bboxes`` / ``face_crop_bboxes`` (tuples of BoundingBox
+        asdicts, or None).
 
     Returns
     -------
-    (panel_bytes, preview_bytes)
-        ``panel_bytes``   — full-resolution packed panel buffer (TOTAL_BYTES long).
-        ``preview_bytes`` — PNG bytes of the preview image.
+    list[dict]
+        Aligned with ``variants``.  ``{"ok": True, "panel_bytes", "preview_bytes"}``
+        on success; ``{"ok": False, "error": str}`` if that one variant's render
+        raised (the others still render).  A *decode* failure raises instead.
+
+    The decoded source is the model/orientation-independent, EXIF-corrected,
+    bbox-shrunk RGB image (see ``open_image_for_render``); the same buffer is
+    valid for every variant, so it is decoded exactly once regardless of how many
+    screens × orientations are rendered.  ``release_input=False`` keeps it alive
+    across the loop; the ``with`` closes it once at the end.
     """
-    # All imports are function-local: this callable runs inside a
-    # ProcessPoolExecutor worker subprocess. The subprocess spawns fresh,
-    # so every module must be imported here rather than relying on parent
-    # process state. PIL format plugins must also be re-registered per process.
+    # All imports are function-local: this callable may run inside a worker
+    # subprocess. The subprocess spawns fresh, so every module must be imported
+    # here rather than relying on parent process state. PIL format plugins must
+    # also be re-registered per process.
     from pathlib import Path  # noqa: PLC0415
 
     import pillow_avif  # noqa: F401, PLC0415 — PIL plugin registration
@@ -78,46 +75,84 @@ def render_one(
     from hokku.webserver.image_abc import preview_png_from_panel_bytes  # noqa: PLC0415
     from hokku.webserver.image_config import _image_config_from_dict  # noqa: PLC0415
     from hokku.webserver.image_renderer import ImageRenderer, open_image_for_render  # noqa: PLC0415
+    from hokku.webserver.orientation import Orientation  # noqa: PLC0415
 
-    display = DISPLAY_REGISTRY[model]
-    cfg = _image_config_from_dict(image_config_dict)
-    renderer = ImageRenderer(NumbaStreamingDither(display), display)
-
-    # Convert bbox dicts back to BoundingBox instances
-    bboxes_norm = None
-    if clahe_keepout_bboxes:
+    def _to_bboxes(raw: tuple[dict, ...] | None) -> tuple[BoundingBox, ...] | None:
+        if not raw:
+            return None
         try:
-            bboxes_norm = tuple(
-                BoundingBox(x=b["x"], y=b["y"], w=b["w"], h=b["h"]) for b in clahe_keepout_bboxes
-            )
+            return tuple(BoundingBox(x=b["x"], y=b["y"], w=b["w"], h=b["h"]) for b in raw)
         except (KeyError, TypeError, ValueError):
-            bboxes_norm = None
+            return None
 
-    crop_anchor_norm = None
-    if face_crop_bboxes:
-        try:
-            crop_anchor_norm = tuple(
-                BoundingBox(x=b["x"], y=b["y"], w=b["w"], h=b["h"]) for b in face_crop_bboxes
-            )
-        except (KeyError, TypeError, ValueError):
-            crop_anchor_norm = None
-
+    results: list[dict] = []
     # NOTE: no RLIMIT_AS cap here (there used to be one). It was virtual-address-
     # space, so it never actually prevented the *physical* OOM it was meant to —
     # that is now handled properly upstream by DECODE_BUDGET_PIXELS, which refuses
-    # an oversized source at ingest before any phase decodes it, so nothing that
-    # reaches this point can blow the RAM budget. Worse, an RLIMIT_AS cap breaks
-    # native decoders that legitimately *reserve* (not commit) large virtual
-    # arenas / thread stacks — libjxl fails with an opaque "Generic Error" under
-    # it (reproduced on the Pi). So the cap was both redundant and harmful.
+    # an oversized source at ingest before any phase decodes it. Worse, an
+    # RLIMIT_AS cap breaks native decoders that legitimately *reserve* (not commit)
+    # large virtual arenas / thread stacks — libjxl fails with an opaque "Generic
+    # Error" under it. So the cap was both redundant and harmful.
+    #
+    # Decode ONCE. A decode failure dooms every variant — let it propagate so the
+    # caller fails the whole image once.
     with open_image_for_render(Path(image_path)) as img:
-        panel_bytes = renderer.render_panel_bytes(
-            img,
-            cfg,
-            orientation,  # type: ignore[arg-type]
-            crop_to_fill_threshold,
-            clahe_keepout_bboxes_norm=bboxes_norm,
-            crop_anchor_bboxes_norm=crop_anchor_norm,
-        )
-    preview_bytes = preview_png_from_panel_bytes(panel_bytes, orientation, display)  # type: ignore[arg-type]
-    return panel_bytes, preview_bytes
+        for variant in variants:
+            try:
+                display = DISPLAY_REGISTRY[variant["model"]]
+                orientation = Orientation(variant["orientation"])
+                cfg = _image_config_from_dict(variant["image_config"])
+                renderer = ImageRenderer(NumbaStreamingDither(display), display)
+                panel_bytes = renderer.render_panel_bytes(
+                    img,
+                    cfg,
+                    orientation,  # type: ignore[arg-type]
+                    variant.get("crop_to_fill_threshold", 0.0),
+                    clahe_keepout_bboxes_norm=_to_bboxes(variant.get("clahe_keepout_bboxes")),
+                    crop_anchor_bboxes_norm=_to_bboxes(variant.get("face_crop_bboxes")),
+                    # Keep the shared source alive for the remaining variants; the
+                    # enclosing `with` closes it once, after the whole batch.
+                    release_input=False,
+                )
+                preview_bytes = preview_png_from_panel_bytes(panel_bytes, orientation, display)  # type: ignore[arg-type]
+                results.append(
+                    {"ok": True, "panel_bytes": panel_bytes, "preview_bytes": preview_bytes}
+                )
+            except Exception as exc:  # isolate one variant's failure
+                # A single variant's render failed (bad config, palette bug, ...).
+                # Record it and keep rendering the others; the manager fails only
+                # this (model, orientation), not the whole image.
+                results.append({"ok": False, "error": f"{type(exc).__name__}: {exc}"})
+    return results
+
+
+def render_one(
+    image_path: str,
+    image_config_dict: dict,
+    model: str,
+    orientation: str,
+    crop_to_fill_threshold: float = 0.0,
+    clahe_keepout_bboxes: tuple[dict, ...] | None = None,
+    face_crop_bboxes: tuple[dict, ...] | None = None,
+) -> tuple[bytes, bytes]:
+    """Render a single (model, orientation) variant.
+
+    Thin wrapper over :func:`render_image_variants` for callers/tests that want
+    one output.  Raises on decode failure (propagated) or on that variant's
+    render failure.
+
+    Returns ``(panel_bytes, preview_bytes)`` — the full-resolution packed panel
+    buffer (``TOTAL_BYTES`` long) and PNG preview bytes.
+    """
+    variant = {
+        "model": model,
+        "orientation": orientation,
+        "image_config": image_config_dict,
+        "crop_to_fill_threshold": crop_to_fill_threshold,
+        "clahe_keepout_bboxes": clahe_keepout_bboxes,
+        "face_crop_bboxes": face_crop_bboxes,
+    }
+    result = render_image_variants(image_path, [variant])[0]
+    if not result["ok"]:
+        raise RuntimeError(result["error"])
+    return result["panel_bytes"], result["preview_bytes"]

--- a/python/hokku/webserver/resource_budget.py
+++ b/python/hokku/webserver/resource_budget.py
@@ -88,6 +88,7 @@ class ResourceBudget:
     cpu_count: int  #: cgroup-aware usable CPU count
     decode_budget_pixels: int  #: max un-draftable source we will decode
     worker_count: int  #: concurrent renders allowed
+    decode_slots: int  #: concurrent source decodes allowed (memory-bounded)
     under_provisioned: bool  #: memory below the healthy floor
 
     def log_line(self) -> str:
@@ -95,7 +96,7 @@ class ResourceBudget:
         return (
             f"Resource budget: memory={self.memory_bytes / _MB:.0f} MB ({src}), "
             f"cpu={self.cpu_count}, decode_budget={self.decode_budget_pixels:,} px, "
-            f"workers={self.worker_count}"
+            f"workers={self.worker_count}, decode_slots={self.decode_slots}"
             + (" [UNDER-PROVISIONED]" if self.under_provisioned else "")
         )
 
@@ -126,18 +127,59 @@ def effective_memory_bytes(memory_budget_mb: int) -> tuple[int, bool]:
 def resolve_worker_count(*, memory_bytes: int, cpu_count: int, decode_budget_pixels: int) -> int:
     """Concurrent-render count — always derived, never manually set.
 
-    Decode is serialized (one at a time via ``_DECODE_LOCK``), so the memory
-    worst case is: baseline + one full-size decode in flight + the remaining
-    workers doing lighter post-decode renders. We reserve baseline plus one
-    worst-case decode, then fit as many additional ``PER_RENDER_BYTES`` renders
-    as remain — capped by the usable CPU count, always at least 1. This couples
-    the worker count to the decode budget so a big decode budget doesn't let
-    parallelism OOM the box.
+    The memory floor reserves one full-size decode in flight plus the remaining
+    workers doing lighter post-decode renders: baseline + one worst-case decode,
+    then as many additional ``PER_RENDER_BYTES`` renders as fit — capped by the
+    usable CPU count, always at least 1. This couples the worker count to the
+    decode budget so a big decode budget doesn't let parallelism OOM the box.
+
+    How many decodes may actually run *concurrently* (rather than the single one
+    reserved here) is a separate, memory-bounded number — see
+    :func:`resolve_decode_concurrency`, which spends any leftover headroom.
     """
     decode_reserve = decode_budget_pixels * DECODE_BYTES_PER_PIXEL
     usable = memory_bytes - BASELINE_RSS_BYTES - decode_reserve
     additional = max(0, int(usable // PER_RENDER_BYTES))
     return max(1, min(cpu_count, 1 + additional))
+
+
+def resolve_decode_concurrency(
+    *, memory_bytes: int, worker_count: int, decode_budget_pixels: int
+) -> int:
+    """How many source decodes may run concurrently, bounded by RAM.
+
+    Serializing every decode behind one lock (the old behaviour) makes a stream
+    of ordinary JPEG/PNG uploads queue behind a single decode. This lets them
+    decode in parallel *up to what memory allows*, so the render pool isn't
+    starved — while never exceeding the budget.
+
+    A decoding worker costs a full ``decode_peak`` (``decode_budget_pixels`` ×
+    ``DECODE_BYTES_PER_PIXEL``); a rendering worker costs ``PER_RENDER_BYTES``.
+    The worst case with K concurrent decodes across ``worker_count`` workers is
+    ``K*decode_peak + (worker_count-K)*PER_RENDER_BYTES``. We return the largest
+    K in ``[1, worker_count]`` that still fits ``memory_bytes``:
+
+      * if a decode is no costlier than a render (small decode budgets — e.g. the
+        Pi at 16 MP: 128 MB < 220 MB), every worker may decode → K = worker_count;
+      * otherwise K starts at the one decode :func:`resolve_worker_count` already
+        reserved and grows by one per ``(decode_peak - PER_RENDER_BYTES)`` of
+        leftover headroom.
+
+    A single-worker box (the appliance) is always K = 1 — fully serialized, no
+    behaviour change. Conservative on purpose: every decode slot is charged the
+    worst-case (HEIF, 8 B/px) cost even though JPEG/PNG decode cheaper, so the
+    bound holds for any format. Per-format decode costs could raise K further
+    later; this keeps the reconciliation provably safe today.
+    """
+    decode_peak = decode_budget_pixels * DECODE_BYTES_PER_PIXEL
+    if decode_peak <= PER_RENDER_BYTES:
+        return max(1, worker_count)
+    usable = memory_bytes - BASELINE_RSS_BYTES
+    # resolve_worker_count guarantees one decode + (worker_count-1) renders fits;
+    # spend any remaining headroom upgrading render slots to decode slots.
+    slack = usable - (decode_peak + (worker_count - 1) * PER_RENDER_BYTES)
+    extra = max(0, int(slack // (decode_peak - PER_RENDER_BYTES)))
+    return max(1, min(worker_count, 1 + extra))
 
 
 def resolve_decode_budget_pixels(memory_bytes: int) -> int:
@@ -163,6 +205,11 @@ def compute_budget(memory_budget_mb: int) -> ResourceBudget:
         cpu_count=cpu_count,
         decode_budget_pixels=decode,
     )
+    decode_slots = resolve_decode_concurrency(
+        memory_bytes=memory_bytes,
+        worker_count=workers,
+        decode_budget_pixels=decode,
+    )
     under = decode < MIN_HEALTHY_DECODE_PIXELS
     return ResourceBudget(
         memory_bytes=memory_bytes,
@@ -170,5 +217,6 @@ def compute_budget(memory_budget_mb: int) -> ResourceBudget:
         cpu_count=cpu_count,
         decode_budget_pixels=decode,
         worker_count=workers,
+        decode_slots=decode_slots,
         under_provisioned=under,
     )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hokku-server"
-version = "4.0.1.dev13"
+version = "4.0.1.dev14"
 description = "Spectra 6 e-ink image server for Hokku EL133UF1 display"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/tests/test_decode_admission.py
+++ b/python/tests/test_decode_admission.py
@@ -1,0 +1,102 @@
+"""Decode admission: the semaphore bounds concurrent decodes; native codecs serialize.
+
+open_image_for_render bounds decoding two ways (see image_renderer):
+  * _DECODE_SEMAPHORE (size from the memory budget) caps *how many* decodes run
+    at once, so the classic formats (JPEG/PNG/...) decode in parallel up to what
+    RAM allows instead of queuing behind one decode;
+  * _NATIVE_DECODE_LOCK additionally serializes the non-thread-safe native codecs
+    (HEIF/AVIF/JXL) to at most one at a time.
+
+These use barriers rather than sleeps so they are deterministic: a barrier that
+is satisfied proves the threads were genuinely concurrent; one that times out
+(``broken``) proves they could not overlap.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from hokku.webserver import image_renderer
+
+
+@pytest.fixture(autouse=True)
+def _restore_decode_semaphore():
+    """Isolate the process-global semaphore each test mutates."""
+    saved = image_renderer._DECODE_SEMAPHORE
+    yield
+    image_renderer._DECODE_SEMAPHORE = saved
+
+
+def _decode_in_threads(monkeypatch, suffixes, *, concurrency, barrier):
+    """Run one open_image_for_render per suffix, each rendezvousing at ``barrier``
+    inside the (faked) decode. Returns the list of exceptions raised per thread."""
+
+    def fake_open(_path):
+        try:
+            barrier.wait()
+        except threading.BrokenBarrierError:
+            pass
+        return object()  # stand-in decoded image; the caller just discards it
+
+    monkeypatch.setattr(image_renderer, "_open_image_for_render", fake_open)
+    image_renderer.set_decode_concurrency(concurrency)
+
+    errors: list[Exception] = []
+
+    def run(path):
+        try:
+            image_renderer.open_image_for_render(path)
+        except Exception as e:  # surface any thread failure to the test
+            errors.append(e)
+
+    threads = [
+        threading.Thread(target=run, args=(Path(f"img{i}{suffix}"),))
+        for i, suffix in enumerate(suffixes)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return errors
+
+
+def test_common_formats_decode_concurrently(monkeypatch):
+    # concurrency 3, three PNGs → all three rendezvous at once (barrier satisfied).
+    barrier = threading.Barrier(3, timeout=5.0)
+    errors = _decode_in_threads(monkeypatch, [".png"] * 3, concurrency=3, barrier=barrier)
+    assert not errors
+    assert not barrier.broken  # all three decoded simultaneously
+
+
+def test_concurrency_one_serializes_common_formats(monkeypatch):
+    # concurrency 1 → two PNGs cannot overlap; the 2-party barrier never fills.
+    barrier = threading.Barrier(2, timeout=1.0)
+    _decode_in_threads(monkeypatch, [".png"] * 2, concurrency=1, barrier=barrier)
+    assert barrier.broken
+
+
+def test_native_codecs_cannot_decode_concurrently(monkeypatch):
+    # Memory permits 4 concurrent decodes, but the native lock still caps HEIF at
+    # one at a time, so a 2-party barrier between two HEIF decodes never fills.
+    barrier = threading.Barrier(2, timeout=1.0)
+    _decode_in_threads(monkeypatch, [".heic"] * 2, concurrency=4, barrier=barrier)
+    assert barrier.broken
+
+
+def test_native_and_common_can_overlap(monkeypatch):
+    # A HEIF and a PNG use different decoders, so only the native lock is
+    # exclusive — they may decode at the same time.
+    barrier = threading.Barrier(2, timeout=5.0)
+    errors = _decode_in_threads(monkeypatch, [".heic", ".png"], concurrency=2, barrier=barrier)
+    assert not errors
+    assert not barrier.broken
+
+
+def test_set_decode_concurrency_floors_at_one(monkeypatch):
+    # A non-positive value must not crash or unbound the pool — it means 1.
+    barrier = threading.Barrier(2, timeout=1.0)
+    _decode_in_threads(monkeypatch, [".png"] * 2, concurrency=0, barrier=barrier)
+    assert barrier.broken

--- a/python/tests/test_image_manager.py
+++ b/python/tests/test_image_manager.py
@@ -246,25 +246,22 @@ def test_inflight_prevents_double_submission(
 
     mgr = image_manager_factory(app_config)
     submitted: list[str] = []
-    original = mgr._dispatch_render
+    original = mgr._submit_image_batch
 
-    def counting(name, expected_slug, model, orientation, render_args, t0, *, update_status=True):
+    def counting(name, variants, t0):
         submitted.append(name)
-        return original(
-            name, expected_slug, model, orientation, render_args, t0, update_status=update_status
-        )
+        return original(name, variants, t0)
 
-    monkeypatch.setattr(mgr, "_dispatch_render", counting)
+    monkeypatch.setattr(mgr, "_submit_image_batch", counting)
 
     mgr.sync()  # submits and completes a.png
     mgr.wait_for_idle()
     mgr.sync()  # a.png is now 'ok'; should NOT resubmit
     mgr.wait_for_idle()
 
-    # Both orientations are dispatched per image; the second sync() must not re-submit.
-    assert submitted == ["a.png", "a.png"], (
-        f"a.png should be submitted exactly twice (both orientations), got {submitted}"
-    )
+    # One decode-once batch per image (both orientations render inside it); the
+    # second sync() must not re-submit an already-converted image.
+    assert submitted == ["a.png"], f"a.png should be batched exactly once, got {submitted}"
 
 
 def test_two_images_both_succeed(app_config: AppConfig, image_manager_factory, make_test_image):

--- a/python/tests/test_image_manager_concrete.py
+++ b/python/tests/test_image_manager_concrete.py
@@ -19,7 +19,6 @@ from hokku.webserver import image_manager_single
 from hokku.webserver.app_config import AppConfig
 from hokku.webserver.image_manager_multi import MultiThreadedImageManager
 from hokku.webserver.image_manager_single import SingleThreadedImageManager
-from hokku.webserver.orientation import Orientation
 
 _HUESSEN = DISPLAY_REGISTRY["huessen_epf1301"]
 TOTAL_BYTES = _HUESSEN.total_bytes
@@ -41,14 +40,16 @@ def test_single_threaded_renders_inline_on_calling_thread(
     make_test_image(upload / "a.png")
     make_test_image(upload / "b.png")
 
-    real_render_one = image_manager_single.render_one
+    real_render_image_variants = image_manager_single.render_image_variants
     render_threads: list[int] = []
 
-    def recording_render_one(*args, **kwargs):
+    def recording_render_image_variants(*args, **kwargs):
         render_threads.append(threading.get_ident())
-        return real_render_one(*args, **kwargs)
+        return real_render_image_variants(*args, **kwargs)
 
-    monkeypatch.setattr(image_manager_single, "render_one", recording_render_one)
+    monkeypatch.setattr(
+        image_manager_single, "render_image_variants", recording_render_image_variants
+    )
 
     mgr = SingleThreadedImageManager(app_config)
     caller_ident = threading.get_ident()
@@ -61,9 +62,8 @@ def test_single_threaded_renders_inline_on_calling_thread(
     assert rec_a is not None and rec_b is not None
     assert rec_a.convert_status == "ok"
     assert rec_b.convert_status == "ok"
-    # Renders actually happened (>= 2: at least one per image; the manager renders
-    # per orientation, so the exact count is an implementation detail), and every
-    # one ran on the calling thread — no worker thread was used.
+    # Renders actually happened (one decode-once batch per image, so >= 2 for two
+    # images), and every one ran on the calling thread — no worker thread was used.
     assert len(render_threads) >= 2, f"expected renders to run, got {render_threads}"
     assert all(t == caller_ident for t in render_threads), (
         f"render ran off the calling thread: caller={caller_ident} renders={render_threads}"
@@ -77,20 +77,30 @@ def test_multi_threaded_runs_in_parallel(app_config: AppConfig, monkeypatch):
     """
     barrier = threading.Barrier(parties=3, timeout=10.0)
 
-    def fake_render_one(*_args, **_kwargs):
+    def fake_render_image_variants(_image_path, variants):
         # If both workers reach this barrier the test thread will too.
         # If only one reaches it, the timeout trips a BrokenBarrierError.
         barrier.wait()
-        return (b"\x00" * TOTAL_BYTES, b"\x89PNG\r\n\x1a\n")
+        return [
+            {
+                "ok": True,
+                "panel_bytes": b"\x00" * TOTAL_BYTES,
+                "preview_bytes": b"\x89PNG\r\n\x1a\n",
+            }
+            for _ in variants
+        ]
 
-    monkeypatch.setattr("hokku.webserver.image_manager_multi.render_one", fake_render_one)
+    monkeypatch.setattr(
+        "hokku.webserver.image_manager_multi.render_image_variants", fake_render_image_variants
+    )
 
     mgr = MultiThreadedImageManager(app_config, worker_count=2)
     try:
-        mgr._dispatch_render("a.png", "slug", "huessen_epf1301", Orientation.LANDSCAPE, (), 0.0)
-        mgr._dispatch_render("b.png", "slug", "huessen_epf1301", Orientation.LANDSCAPE, (), 0.0)
-        # Joining the barrier proves both workers entered fake_render_one
-        # concurrently. Raises BrokenBarrierError if only one did.
+        # Two images → two decode-once batches → two executor jobs. Joining the
+        # barrier proves both jobs entered the worker concurrently; a serial pool
+        # would leave one waiting and trip BrokenBarrierError on timeout.
+        mgr._run_batch("a.png", [{"model": "huessen_epf1301", "orientation": "landscape"}])
+        mgr._run_batch("b.png", [{"model": "huessen_epf1301", "orientation": "landscape"}])
         barrier.wait(timeout=5.0)
     finally:
         mgr.shutdown()

--- a/python/tests/test_render_worker.py
+++ b/python/tests/test_render_worker.py
@@ -12,9 +12,10 @@ from pathlib import Path
 
 import pytest
 
+import hokku.webserver.image_renderer as image_renderer
 from hokku.screens.registry import DISPLAY_REGISTRY
 from hokku.webserver.presets import PRESET_IMAGE_CONFIGS
-from hokku.webserver.render_worker import render_one
+from hokku.webserver.render_worker import render_image_variants, render_one
 
 _HUESSEN = DISPLAY_REGISTRY["huessen_epf1301"]
 
@@ -121,3 +122,67 @@ def test_render_one_renders_jxl():
 def test_render_one_bad_path_raises():
     with pytest.raises(FileNotFoundError):
         render_one("/nonexistent/path/image.png", _cfg_dict(), "huessen_epf1301", "landscape")
+
+
+# ── decode-once: many variants, one decode ────────────────────────────────────
+
+
+def test_render_image_variants_decodes_source_once(monkeypatch):
+    """render_image_variants decodes the source exactly once for N variants.
+
+    The whole point of the batch: the source is decoded a single time and every
+    (model, orientation) variant is dithered off that one buffer. Regression
+    guard — previously each variant re-decoded (and re-took the decode lock).
+    """
+    decode_calls = {"n": 0}
+    real_open = image_renderer.open_image_for_render
+
+    def counting_open(path):
+        decode_calls["n"] += 1
+        return real_open(path)
+
+    # The worker imports open_image_for_render from image_renderer at call time,
+    # so patching the module attribute is picked up inside render_image_variants.
+    monkeypatch.setattr(image_renderer, "open_image_for_render", counting_open)
+
+    variants = [
+        {"model": "huessen_epf1301", "orientation": "landscape", "image_config": _cfg_dict()},
+        {"model": "huessen_epf1301", "orientation": "portrait", "image_config": _cfg_dict()},
+    ]
+    results = render_image_variants(str(_FIXTURE_PNG), variants)
+
+    assert decode_calls["n"] == 1, f"source must decode once, decoded {decode_calls['n']}x"
+    assert len(results) == 2
+    assert all(r["ok"] for r in results)
+    assert all(len(r["panel_bytes"]) == _HUESSEN.total_bytes for r in results)
+    # Distinct orientations → distinct panels. Also proves the shared decoded
+    # buffer survived the first render (release_input=False): if the first variant
+    # had closed it, the second would have failed or produced garbage.
+    assert results[0]["panel_bytes"] != results[1]["panel_bytes"]
+
+
+def test_render_image_variants_isolates_one_variant_failure():
+    """A single bad variant fails alone; siblings still render.
+
+    Decode succeeds, so the batch does not raise; the bad variant (unknown model)
+    comes back ``ok=False`` while the good one renders normally.
+    """
+    variants = [
+        {"model": "huessen_epf1301", "orientation": "landscape", "image_config": _cfg_dict()},
+        {"model": "no_such_model", "orientation": "landscape", "image_config": _cfg_dict()},
+    ]
+    results = render_image_variants(str(_FIXTURE_PNG), variants)
+
+    assert results[0]["ok"] is True
+    assert len(results[0]["panel_bytes"]) == _HUESSEN.total_bytes
+    assert results[1]["ok"] is False
+    assert "error" in results[1]
+
+
+def test_render_image_variants_decode_failure_raises():
+    """A source that cannot be decoded dooms every variant → the call raises."""
+    variants = [
+        {"model": "huessen_epf1301", "orientation": "landscape", "image_config": _cfg_dict()},
+    ]
+    with pytest.raises(FileNotFoundError):
+        render_image_variants("/nonexistent/path/image.png", variants)

--- a/python/tests/test_resource_budget.py
+++ b/python/tests/test_resource_budget.py
@@ -9,12 +9,15 @@ import pytest
 from hokku.webserver import resource_budget as rb
 from hokku.webserver.resource_budget import (
     BASELINE_RSS_BYTES,
+    DECODE_BYTES_PER_PIXEL,
     MAX_DECODE_BUDGET_PIXELS,
     MIN_MEMORY_BUDGET_MB,
+    PER_RENDER_BYTES,
     compute_budget,
     effective_memory_bytes,
     memory_budget_too_low,
     resolve_decode_budget_pixels,
+    resolve_decode_concurrency,
     resolve_worker_count,
 )
 
@@ -65,6 +68,68 @@ def test_workers_below_baseline_clamps_to_1():
 
 def test_workers_always_at_least_1():
     assert resolve_worker_count(memory_bytes=1, cpu_count=1, decode_budget_pixels=0) == 1
+
+
+# ── decode concurrency (admission slots) ──────────────────────────────────────
+
+
+def test_decode_concurrency_single_worker_is_serial():
+    # The appliance: one worker → one decode at a time, unchanged behaviour.
+    assert (
+        resolve_decode_concurrency(
+            memory_bytes=464 * _MB, worker_count=1, decode_budget_pixels=16_000_000
+        )
+        == 1
+    )
+
+
+def test_decode_concurrency_cheap_decode_allows_all_workers():
+    # When a decode is no costlier than a render (decode_peak <= PER_RENDER),
+    # every worker may decode concurrently.
+    decode_peak_eq_render = PER_RENDER_BYTES // DECODE_BYTES_PER_PIXEL
+    assert (
+        resolve_decode_concurrency(
+            memory_bytes=64 * 1024**3,
+            worker_count=5,
+            decode_budget_pixels=decode_peak_eq_render,
+        )
+        == 5
+    )
+
+
+def test_decode_concurrency_medium_box_allows_two():
+    # 1 GB / worker_count 2 / 40 MP: the one reserved decode plus leftover
+    # headroom fits a second concurrent decode.
+    assert (
+        resolve_decode_concurrency(
+            memory_bytes=1024 * _MB, worker_count=2, decode_budget_pixels=40_000_000
+        )
+        == 2
+    )
+
+
+def test_decode_concurrency_never_exceeds_workers():
+    k = resolve_decode_concurrency(
+        memory_bytes=64 * 1024**3, worker_count=3, decode_budget_pixels=40_000_000
+    )
+    assert 1 <= k <= 3
+
+
+@pytest.mark.parametrize("mb", [512, 768, 1024, 2048, 4096, 8192])
+def test_compute_budget_decode_slots_are_memory_safe(mb):
+    # Provable invariant: the worst case of decode_slots concurrent decodes plus
+    # the remaining workers rendering must fit the usable budget. If this ever
+    # fails, concurrent decodes could OOM the box.
+    with (
+        patch.object(rb, "detect_memory_limit_bytes", return_value=mb * _MB),
+        patch.object(rb, "detect_cpu_limit", return_value=24),
+    ):
+        b = compute_budget(0)
+    assert 1 <= b.decode_slots <= b.worker_count
+    decode_peak = b.decode_budget_pixels * DECODE_BYTES_PER_PIXEL
+    usable = b.memory_bytes - BASELINE_RSS_BYTES
+    worst = b.decode_slots * decode_peak + (b.worker_count - b.decode_slots) * PER_RENDER_BYTES
+    assert worst <= usable
 
 
 # ── decode budget ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two render-pipeline changes that compose with the memory budget (#27), plus a small dev-version bump. Two commits:

### 1. Decode-once, dither-many
A render job is now the **whole image** rather than one `(model, orientation)` pair. `render_worker.render_image_variants` decodes the source a **single time** and dithers every variant off that one buffer (`render_panel_bytes` gains `release_input=False` so the shared buffer survives the loop, closed once at the end). Previously `render_one` re-decoded per variant, so a HEIF rendered to 2 orientations × N models decoded **2N times**, each re-taking the decode lock.

The manager batches all uncached variants of an image into one job (`_run_batch`) and replays the existing `_on_render_done` per variant, so the `pending→ok` / primary-secondary / cache-hit lifecycle is **byte-for-byte unchanged**. `render_one` is kept as a thin single-variant wrapper for callers/tests.

### 2. Memory-bounded decode admission (parallel JPEG/PNG decodes, safely)
Re-enables concurrent decoding of the common formats without breaking the budget's "one decode at a time" invariant. Two independent bounds on `open_image_for_render`:

- **Memory** — every decode takes a permit from `_DECODE_SEMAPHORE`, sized from the budget via `resource_budget.resolve_decode_concurrency` and installed by `set_decode_concurrency()` (startup + every reload). At most **K** decodes run at once; K is chosen so `K·decode_peak + (workers−K)·render_peak` fits the budget — **provably safe by construction** (there's a test asserting that invariant across box sizes). **K=1 on a single-worker box (the Pi)** — identical to the old global lock, zero appliance change.
- **Thread-safety** — the native container codecs (HEIF/AVIF/JXL) additionally take `_NATIVE_DECODE_LOCK`, so at most one native decode runs at a time regardless of K (libheif is not thread-safe). A native and a common-format decode may still overlap. Acquisition order is always semaphore → native lock, so the two never deadlock.

`resolve_decode_concurrency` spends only the headroom left after `resolve_worker_count` reserved its one decode, so worker throughput is never traded for decode slots. Conservative on purpose: every slot is charged the worst-case (HEIF, 8 B/px) cost, so the bound holds for any format. `ResourceBudget` gains a `decode_slots` field (shown in `log_line`).

**Behavior by box:** Pi (1 worker) → K=1 (unchanged); ~1 GB / 2 workers → K=2; larger boxes → whatever headroom remains after workers are maximized.

## Why the decode lock stays (mostly) serialized
The budget's worker-count formula reserves `baseline + one worst-case decode + N lighter renders` — only safe while decode is serialized. Rather than revert that or over-reserve, this PR makes the concurrency **a budget-derived number** and keeps native codecs mutually exclusive for correctness.

## Testing
- **Full suite: 795 passed, 5 skipped.** ruff + ruff-format + pyright clean (pre-commit hooks pass).
- New: decode-happens-exactly-once, per-variant failure isolation, decode-failure-dooms-the-batch; `resolve_decode_concurrency` math + a memory-safety invariant sweep across box sizes; deterministic **barrier-based** concurrency tests (common formats decode together, K=1 serializes, native codecs never overlap, native+common may overlap).
- Updated the three dispatch tests that drove the old per-variant `_dispatch_render` to the new batch contract, preserving their intent.

## Follow-up (not in this PR)
The conservative worst-case-per-slot cost means K stays low on very large boxes. Per-format decode costs (cheap JPEG vs expensive HEIF) could raise K further — noted in the code as the next refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
