### PR TITLE
Flashing a screen wrote to a slot the device never booted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,19 @@ that the host mocks lack — that only fails later in CI's `test-firmware-*` job
 (on Windows/MSVC add `-C Debug` to ctest). When you call a new esp-idf function, add a
 stub for it under `firmware/common/esp32/test/mocks/`.
 
+## Flashing — always show what is being written
+
+**Rule**: every flasher MUST name, for **each** region it writes, the file (or what the
+image is), its size, and the destination offset/slot — before writing it. This holds
+equally for the web "Flash a screen" UI and the `tools/` CLI scripts; a bare
+"Flashing firmware..." or "Writing configuration..." is not enough. A flash that writes
+three regions prints three lines. The descriptions live next to the flashing code (e.g.
+`describe_flash_parts` / `describe_config_part` in `hokku.common.esp32.flasher`) and are
+shared by every front end, so the web UI and the CLI cannot drift apart.
+
+Rationale: a flash silently landing in a partition the device does not boot cost real
+debugging time. What the operator sees must match what the flasher actually does.
+
 ## Tool scripts
 - All standalone Python helper/dev scripts belong in `tools/`
 - Do not create or leave `.py` files in the repo root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@
 
 ### Fixed
 
+- **Scanning for a screen to flash no longer kicks it into a refresh.** The scan
+  used to leave the screen running, and since a screen repaints on boot, the act
+  of looking for a device to flash started a ~30-60s panel refresh — at exactly
+  the moment the operator was about to flash and interrupt it. A scan now leaves
+  the screen in its bootloader, which is what the flash wants anyway; the panel
+  keeps displaying its last image throughout, because e-paper holds its image
+  without power. If no flash follows within five minutes the server boots the
+  screen back into its firmware on its own, so a scan you abandon costs nothing.
+
 - **Flashing a screen no longer leaves a half-painted panel.** Each esptool step
   reset the ESP32, and because a cold boot immediately downloads an image and
   repaints the display (~28 s), every reset *started* a paint that the next step

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@
 
 ### Fixed
 
+- **Flashing now shows what it writes where.** Both the web *Flash a screen* page and
+  the `tools/` CLI name every region a flash touches — the firmware file and its size
+  going to `0x0`, the blank `otadata`, and the generated NVS config image — each with
+  its destination offset, before it is written. Previously the config step said only
+  "Writing configuration..." and the CLI printed nothing at all, so there was no way to
+  tell from the output which image had landed in which partition.
+
 - **Flashing a screen over USB could leave it running its old firmware.** The
   merged firmware image covers the bootloader, partition table and the `ota_0`
   app slot, but not `otadata` — the record that tells the bootloader which of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@
 
 ### Fixed
 
+- **Flashing a screen no longer leaves a half-painted panel.** Each esptool step
+  reset the ESP32, and because a cold boot immediately downloads an image and
+  repaints the display (~28 s), every reset *started* a paint that the next step
+  then interrupted a second or two in. That left the panel controller wedged
+  holding BUSY, so the following paint spent its 60 s timeout on every BUSY wait
+  and took ~6 minutes instead of ~28 s — with a half-rendered image on the glass
+  in the meantime. A flash now runs every step with `--after no-reset` and boots
+  the app exactly once, when all flash traffic is done. A screen scan likewise
+  resets once instead of once per region read.
+
 - **Flashing now shows what it writes where.** Both the web *Flash a screen* page and
   the `tools/` CLI name every region a flash touches — the firmware file and its size
   going to `0x0`, the blank `otadata`, and the generated NVS config image — each with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@
 
 ### Fixed
 
+- **Flashing a screen over USB could leave it running its old firmware.** The
+  merged firmware image covers the bootloader, partition table and the `ota_0`
+  app slot, but not `otadata` — the record that tells the bootloader which of the
+  two A/B slots to run. A screen that had previously taken an over-the-air update
+  boots from `ota_1`, so a USB flash wrote the new firmware into a slot the
+  bootloader was ignoring: the flash reported success, the version in the GUI
+  went up, and the screen quietly carried on running the old build. Flashing now
+  clears `otadata` so the freshly written slot is the one that boots. Relatedly,
+  the screen scan used to read the version out of `ota_0` regardless of which
+  slot was active, which is what made this invisible; it now consults `otadata`
+  and reports the version the device actually runs.
+
 - **The server package shipped incomplete data files.** The pip wheel declared
   only the face-detection model as package data, so the Flask `templates/` and
   `static/` trees were silently dropped — a plain `pip install` of the server

--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,3 +1,15 @@
+hokku-server (4.0.1~dev.10-1) unstable; urgency=medium
+
+  * fix(flash): do not reset the screen between flash steps. Every esptool step
+    reset the ESP32, and a cold boot immediately repaints the panel (~28s), so
+    each reset started a paint that the next step interrupted mid-refresh,
+    wedging the panel controller (BUSY held, every wait burning its 60s timeout,
+    a ~6 minute paint and a half-rendered image on the glass). All steps now run
+    --after no-reset and the app is booted exactly once, at the end. Scans reset
+    once instead of once per region read.
+
+ -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Sun, 27 Jul 2026 04:45:00 +0000
+
 hokku-server (4.0.1~dev.9-1) unstable; urgency=medium
 
   * flash: name every region a flash writes — the firmware file and its size to

--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,36 +1,27 @@
-hokku-server (4.0.1~dev.10-1) unstable; urgency=medium
+hokku-server (4.0.1~dev.11-1) unstable; urgency=medium
 
-  * fix(flash): do not reset the screen between flash steps. Every esptool step
-    reset the ESP32, and a cold boot immediately repaints the panel (~28s), so
-    each reset started a paint that the next step interrupted mid-refresh,
-    wedging the panel controller (BUSY held, every wait burning its 60s timeout,
-    a ~6 minute paint and a half-rendered image on the glass). All steps now run
-    --after no-reset and the app is booted exactly once, at the end. Scans reset
-    once instead of once per region read.
-
- -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Sun, 27 Jul 2026 04:45:00 +0000
-
-hokku-server (4.0.1~dev.9-1) unstable; urgency=medium
-
-  * flash: name every region a flash writes — the firmware file and its size to
-    0x0, the blank otadata, and the generated NVS config image — each with its
+  * fix(flash): clear otadata when flashing a screen over USB. The merged image
+    only covers ota_0, so a screen that had taken an OTA kept booting the older
+    firmware left in ota_1 and silently ignored everything just written. The
+    screen scan also read the version out of ota_0 regardless of which slot was
+    active, which is what made this invisible; it now reports the slot the device
+    actually boots.
+  * fix(flash): never reset the screen between flash steps. A reset boots the app
+    and a boot repaints the panel (~30s), so each step started a paint the next
+    step interrupted mid-refresh -- wedging the panel controller, which then held
+    BUSY and burned a 60s timeout on every wait (a ~6 minute paint, half-rendered
+    image on the glass). Every step now runs --after no-reset and the app boots
+    exactly once, at the end.
+  * fix(flash): a device scan no longer starts a panel refresh. Scanning left the
+    screen running, so looking for a device to flash began a refresh right before
+    the flash interrupted it. The scan now leaves the screen in its bootloader
+    (the panel keeps its last image -- e-paper holds without power); if no flash
+    follows within five minutes the server boots it back into firmware itself.
+  * flash: name every region a flash writes -- the firmware file and its size to
+    0x0, the blank otadata, and the generated NVS config image -- each with its
     destination offset, in both the web "Flash a screen" page and the tools/ CLI.
-  * fix(flash): write the blank otadata as part of the firmware write-flash pass
-    instead of a separate erase-region call, so a flash costs one esptool connect
-    and reset rather than two. Fewer resets mid-flash is safer for the panel
-    controller, which does not always survive being reset mid-transaction.
 
- -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Sun, 27 Jul 2026 04:15:00 +0000
-
-hokku-server (4.0.1~dev.8-1) unstable; urgency=medium
-
-  * fix(flash): clear otadata when flashing a screen over USB, so the bootloader
-    runs the firmware that was just written instead of whatever an earlier OTA
-    left in the other A/B slot. Also report the version of the slot the device
-    actually boots, so a screen can no longer appear up to date while running
-    older firmware.
-
- -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Sun, 27 Jul 2026 03:30:00 +0000
+ -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Mon, 27 Jul 2026 12:40:00 +0000
 
 hokku-server (4.0.1~dev.13-1) unstable; urgency=medium
 

--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,3 +1,15 @@
+hokku-server (4.0.1~dev.9-1) unstable; urgency=medium
+
+  * flash: name every region a flash writes — the firmware file and its size to
+    0x0, the blank otadata, and the generated NVS config image — each with its
+    destination offset, in both the web "Flash a screen" page and the tools/ CLI.
+  * fix(flash): write the blank otadata as part of the firmware write-flash pass
+    instead of a separate erase-region call, so a flash costs one esptool connect
+    and reset rather than two. Fewer resets mid-flash is safer for the panel
+    controller, which does not always survive being reset mid-transaction.
+
+ -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Sun, 27 Jul 2026 04:15:00 +0000
+
 hokku-server (4.0.1~dev.8-1) unstable; urgency=medium
 
   * fix(flash): clear otadata when flashing a screen over USB, so the bootloader

--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,3 +1,13 @@
+hokku-server (4.0.1~dev.8-1) unstable; urgency=medium
+
+  * fix(flash): clear otadata when flashing a screen over USB, so the bootloader
+    runs the firmware that was just written instead of whatever an earlier OTA
+    left in the other A/B slot. Also report the version of the slot the device
+    actually boots, so a screen can no longer appear up to date while running
+    older firmware.
+
+ -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Sun, 27 Jul 2026 03:30:00 +0000
+
 hokku-server (4.0.1~dev.13-1) unstable; urgency=medium
 
   * Firmware library: optionally download firmware from GitHub Releases and pin a

--- a/python/hokku/common/esp32/device.py
+++ b/python/hokku/common/esp32/device.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 
 import logging
 import os
+import struct
 import subprocess
 import sys
 import tempfile
+import zlib
 
 import serial.tools.list_ports
 
@@ -42,14 +44,57 @@ def list_serial_ports(spec: Esp32Spec) -> list[dict]:
     return ports
 
 
-def read_device_flash(
-    spec: Esp32Spec, port: str, timeout: int = 60
-) -> tuple[bytes | None, bytes | None]:
-    """One esptool read covering the NVS partition + app header.
+# otadata holds two ``esp_ota_select_entry_t`` records, each at the start of its
+# own 4 KB sector; the app slots they choose between are ota_0 and ota_1.
+_OTA_SELECT_SECTOR = 0x1000
+_OTA_SELECT_ENTRY_SIZE = 32
+_OTA_APP_COUNT = 2
 
-    Returns ``(nvs_bytes, app_header_bytes)`` or ``(None, None)`` on failure.
+
+def _ota_select_seq(entry: bytes) -> int | None:
+    """``ota_seq`` from one otadata entry, or None if blank or CRC-invalid.
+
+    Layout is ``uint32 ota_seq; uint8 label[20]; uint32 state; uint32 crc``, with
+    ``crc = crc32_le(UINT32_MAX, &ota_seq, 4)`` — the bootloader ignores entries
+    whose CRC does not match, so this must too.
     """
-    read_size = (spec.app_offset + 256) - spec.nvs_offset
+    if len(entry) < _OTA_SELECT_ENTRY_SIZE:
+        return None
+    (seq,) = struct.unpack_from("<I", entry, 0)
+    (crc,) = struct.unpack_from("<I", entry, 28)
+    if seq == 0xFFFFFFFF:
+        return None
+    if zlib.crc32(struct.pack("<I", seq), 0xFFFFFFFF) & 0xFFFFFFFF != crc:
+        return None
+    return seq
+
+
+def active_ota_slot(otadata: bytes | None) -> int:
+    """Which app slot the bootloader will run, from the raw otadata partition.
+
+    Mirrors the IDF bootloader: the higher of the two valid ``ota_seq`` values
+    wins and selects slot ``(seq - 1) % 2``. When neither entry is valid — blank
+    otadata, which is what a USB flash leaves behind — it falls back to ota_0.
+    """
+    if not otadata:
+        return 0
+    seqs = [
+        seq
+        for seq in (
+            _ota_select_seq(otadata[:_OTA_SELECT_ENTRY_SIZE]),
+            _ota_select_seq(
+                otadata[_OTA_SELECT_SECTOR : _OTA_SELECT_SECTOR + _OTA_SELECT_ENTRY_SIZE]
+            ),
+        )
+        if seq is not None
+    ]
+    if not seqs:
+        return 0
+    return (max(seqs) - 1) % _OTA_APP_COUNT
+
+
+def _read_region(spec: Esp32Spec, port: str, offset: int, size: int, timeout: int) -> bytes | None:
+    """One esptool ``read-flash`` of *size* bytes at *offset*; None on failure."""
     with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
         tmp_path = f.name
     try:
@@ -65,8 +110,8 @@ def read_device_flash(
                 "--baud",
                 spec.baud,
                 "read-flash",
-                hex(spec.nvs_offset),
-                hex(read_size),
+                hex(offset),
+                hex(size),
                 tmp_path,
             ],
             capture_output=True,
@@ -74,19 +119,44 @@ def read_device_flash(
             timeout=timeout,
         )
         if result.returncode != 0:
-            return None, None
+            return None
         with open(tmp_path, "rb") as f:
-            data = f.read()
-        nvs_data = data[: spec.nvs_size]
-        app_header = data[spec.app_offset - spec.nvs_offset :][:256]
-        return nvs_data, app_header
+            return f.read()
     except (OSError, subprocess.SubprocessError):
-        return None, None
+        return None
     finally:
         try:
             os.unlink(tmp_path)
         except OSError:
             pass
+
+
+def read_device_flash(
+    spec: Esp32Spec, port: str, timeout: int = 60
+) -> tuple[bytes | None, bytes | None]:
+    """Read the NVS partition + the app header of the slot the device *boots*.
+
+    otadata is consulted rather than assuming ota_0: a device that has taken an
+    OTA boots ota_1, and reading ota_0's header would report a version the
+    bootloader is ignoring — which is exactly how a stale device passes for
+    up to date. Costs one extra esptool read, and a third only when ota_1 wins.
+
+    Returns ``(nvs_bytes, app_header_bytes)`` or ``(None, None)`` on failure.
+    """
+    read_size = (spec.app_offset + 256) - spec.nvs_offset
+    data = _read_region(spec, port, spec.nvs_offset, read_size, timeout)
+    if data is None:
+        return None, None
+    nvs_data = data[: spec.nvs_size]
+    app_header = data[spec.app_offset - spec.nvs_offset :][:256]
+
+    # A failed otadata read falls back to the ota_0 header read above.
+    otadata = _read_region(spec, port, spec.otadata_offset, spec.otadata_size, timeout)
+    if active_ota_slot(otadata) == 1:
+        ota1_header = _read_region(spec, port, spec.ota1_offset, 256, timeout)
+        if ota1_header is not None:
+            app_header = ota1_header
+    return nvs_data, app_header
 
 
 def _version_from_header(header: bytes | None) -> str | None:

--- a/python/hokku/common/esp32/device.py
+++ b/python/hokku/common/esp32/device.py
@@ -256,11 +256,20 @@ def parse_device_state(
     return result
 
 
-def scan_devices(spec: Esp32Spec) -> list[dict]:
+def scan_devices(spec: Esp32Spec, boot_after: bool = True) -> list[dict]:
     """Enumerate all serial ports; for ESP32-S3 ports, read on-flash state.
 
-    Each ESP32-S3 device is read (which resets it), so only call this when no
-    flash is in progress. Returns a list of dicts (one per serial port).
+    Each ESP32-S3 device is driven over the same serial port a flash uses, so
+    only call this when no flash is in progress.
+
+    *boot_after* controls whether a scanned device is left running its firmware.
+    A caller that is about to flash passes False: booting starts a full panel
+    repaint (~28 s) at exactly the moment the operator is about to flash, and the
+    flash then interrupts that paint and wedges the panel controller. The panel
+    keeps showing its last image while held in the bootloader (e-paper is
+    persistent), but such a caller MUST guarantee an eventual boot.
+
+    Returns a list of dicts (one per serial port).
     """
     all_ports = list_serial_ports(spec)
     logger.info(
@@ -283,7 +292,7 @@ def scan_devices(spec: Esp32Spec) -> list[dict]:
             }
         )
         if dev["is_esp32"]:
-            nvs_data, app_header = read_device_flash(spec, dev["port"])
+            nvs_data, app_header = read_device_flash(spec, dev["port"], boot_after=boot_after)
             dev.update(parse_device_state(spec, nvs_data, app_header, release_header))
             state = dev
             logger.info(

--- a/python/hokku/common/esp32/device.py
+++ b/python/hokku/common/esp32/device.py
@@ -93,8 +93,33 @@ def active_ota_slot(otadata: bytes | None) -> int:
     return (max(seqs) - 1) % _OTA_APP_COUNT
 
 
+def boot_app(spec: Esp32Spec, port: str, timeout: int = 60) -> bool:
+    """Leave the device running its application firmware.
+
+    Every flash/read step runs with ``--after no-reset``, because an esptool
+    reset boots the app and a boot immediately downloads and repaints the panel
+    (~28 s). Resetting between steps therefore *starts* a paint that the next
+    step interrupts mid-refresh, which leaves the panel controller wedged
+    holding BUSY — every subsequent BUSY wait then burns its full 60 s timeout.
+    So the app is booted exactly once, here, when all flash traffic is done.
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "esptool", "--chip", "esp32s3", "--port", port, "run"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
 def _read_region(spec: Esp32Spec, port: str, offset: int, size: int, timeout: int) -> bytes | None:
-    """One esptool ``read-flash`` of *size* bytes at *offset*; None on failure."""
+    """One esptool ``read-flash`` of *size* bytes at *offset*; None on failure.
+
+    Never resets the chip afterwards — see :func:`boot_app`.
+    """
     with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
         tmp_path = f.name
     try:
@@ -109,6 +134,8 @@ def _read_region(spec: Esp32Spec, port: str, offset: int, size: int, timeout: in
                 port,
                 "--baud",
                 spec.baud,
+                "--after",
+                "no-reset",
                 "read-flash",
                 hex(offset),
                 hex(size),
@@ -132,7 +159,7 @@ def _read_region(spec: Esp32Spec, port: str, offset: int, size: int, timeout: in
 
 
 def read_device_flash(
-    spec: Esp32Spec, port: str, timeout: int = 60
+    spec: Esp32Spec, port: str, timeout: int = 60, boot_after: bool = True
 ) -> tuple[bytes | None, bytes | None]:
     """Read the NVS partition + the app header of the slot the device *boots*.
 
@@ -141,22 +168,30 @@ def read_device_flash(
     bootloader is ignoring — which is exactly how a stale device passes for
     up to date. Costs one extra esptool read, and a third only when ota_1 wins.
 
+    None of the reads reset the chip; unless *boot_after* is False the app is
+    booted once at the end (see :func:`boot_app`). Callers that will keep
+    flashing pass ``boot_after=False`` and boot when they are done.
+
     Returns ``(nvs_bytes, app_header_bytes)`` or ``(None, None)`` on failure.
     """
-    read_size = (spec.app_offset + 256) - spec.nvs_offset
-    data = _read_region(spec, port, spec.nvs_offset, read_size, timeout)
-    if data is None:
-        return None, None
-    nvs_data = data[: spec.nvs_size]
-    app_header = data[spec.app_offset - spec.nvs_offset :][:256]
+    try:
+        read_size = (spec.app_offset + 256) - spec.nvs_offset
+        data = _read_region(spec, port, spec.nvs_offset, read_size, timeout)
+        if data is None:
+            return None, None
+        nvs_data = data[: spec.nvs_size]
+        app_header = data[spec.app_offset - spec.nvs_offset :][:256]
 
-    # A failed otadata read falls back to the ota_0 header read above.
-    otadata = _read_region(spec, port, spec.otadata_offset, spec.otadata_size, timeout)
-    if active_ota_slot(otadata) == 1:
-        ota1_header = _read_region(spec, port, spec.ota1_offset, 256, timeout)
-        if ota1_header is not None:
-            app_header = ota1_header
-    return nvs_data, app_header
+        # A failed otadata read falls back to the ota_0 header read above.
+        otadata = _read_region(spec, port, spec.otadata_offset, spec.otadata_size, timeout)
+        if active_ota_slot(otadata) == 1:
+            ota1_header = _read_region(spec, port, spec.ota1_offset, 256, timeout)
+            if ota1_header is not None:
+                app_header = ota1_header
+        return nvs_data, app_header
+    finally:
+        if boot_after:
+            boot_app(spec, port, timeout)
 
 
 def _version_from_header(header: bytes | None) -> str | None:

--- a/python/hokku/common/esp32/flasher.py
+++ b/python/hokku/common/esp32/flasher.py
@@ -108,9 +108,10 @@ def flash_firmware(
     chip into download mode and hard-resets it, which is worth avoiding: the
     panel controller does not always survive being reset mid-transaction.
     """
-    for part in describe_flash_parts(spec, firmware_path):
-        on_line(f"Flashing {part}")
-    on_line("(~30s)...")
+    parts = describe_flash_parts(spec, firmware_path)
+    on_line(f"Flashing {len(parts)} regions (~30s):")
+    for part in parts:
+        on_line(f"  {part}")
     with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
         f.write(b"\xff" * spec.otadata_size)
         blank_otadata = f.name

--- a/python/hokku/common/esp32/flasher.py
+++ b/python/hokku/common/esp32/flasher.py
@@ -64,10 +64,40 @@ def _run_esptool(args: list[str], on_line: OnLine) -> None:
         raise EsptoolError(f"esptool exited {proc.returncode} (command: esptool {' '.join(args)})")
 
 
+def erase_otadata(spec: Esp32Spec, port: str, on_line: OnLine = _noop) -> None:
+    """Erase the otadata partition so the bootloader runs the app in ota_0.
+
+    The merged image covers bootloader + partition table + ota_0 only; it does
+    not include otadata. A device that has taken an OTA has otadata selecting
+    ota_1, so without this it would keep booting the *old* firmware left there
+    and silently ignore everything just written to ota_0. Blanking otadata makes
+    the bootloader fall back to ota_0 — the image we just flashed.
+    """
+    on_line("Clearing OTA slot selection...")
+    _run_esptool(
+        [
+            "--chip",
+            "esp32s3",
+            "--port",
+            port,
+            "--baud",
+            spec.baud,
+            "erase-region",
+            hex(spec.otadata_offset),
+            hex(spec.otadata_size),
+        ],
+        on_line,
+    )
+
+
 def flash_firmware(
     spec: Esp32Spec, port: str, firmware_path: Path, on_line: OnLine = _noop
 ) -> None:
-    """Write the merged firmware image at the bootloader offset (0x0)."""
+    """Write the merged firmware image at the bootloader offset (0x0).
+
+    Followed by :func:`erase_otadata`, without which the freshly written ota_0
+    is not what the device boots (see that function).
+    """
     on_line(f"Flashing firmware {Path(firmware_path).name} (~30s)...")
     _run_esptool(
         [
@@ -89,6 +119,7 @@ def flash_firmware(
         ],
         on_line,
     )
+    erase_otadata(spec, port, on_line)
 
 
 def write_config(spec: Esp32Spec, port: str, config: dict, on_line: OnLine = _noop) -> None:

--- a/python/hokku/common/esp32/flasher.py
+++ b/python/hokku/common/esp32/flasher.py
@@ -16,7 +16,7 @@ import tempfile
 from collections.abc import Callable
 from pathlib import Path
 
-from hokku.common.esp32.device import parse_device_state, read_device_flash
+from hokku.common.esp32.device import boot_app, parse_device_state, read_device_flash
 from hokku.common.esp32.nvs import build_nvs_binary
 from hokku.common.esp32.spec import Esp32Spec
 
@@ -92,7 +92,11 @@ def describe_config_part(spec: Esp32Spec) -> str:
 
 
 def flash_firmware(
-    spec: Esp32Spec, port: str, firmware_path: Path, on_line: OnLine = _noop
+    spec: Esp32Spec,
+    port: str,
+    firmware_path: Path,
+    on_line: OnLine = _noop,
+    boot_after: bool = True,
 ) -> None:
     """Write the merged firmware image and blank otadata, in one esptool pass.
 
@@ -103,10 +107,12 @@ def flash_firmware(
     silently ignores everything just written to ota_0.
 
     Blank otadata is simply all-0xFF, so it is written as another region of the
-    same ``write-flash`` rather than a separate ``erase-region`` call — one
-    connect and one reset instead of two. Each extra esptool cycle drops the
-    chip into download mode and hard-resets it, which is worth avoiding: the
-    panel controller does not always survive being reset mid-transaction.
+    same ``write-flash`` rather than a separate ``erase-region`` call.
+
+    The write itself never resets the chip. *boot_after* then boots the app so a
+    standalone caller does not strand the device halted in the flasher stub;
+    callers that will keep flashing pass False and boot when they are done (see
+    :func:`device.boot_app` for why the boot count matters).
     """
     parts = describe_flash_parts(spec, firmware_path)
     on_line(f"Flashing {len(parts)} regions (~30s):")
@@ -124,6 +130,8 @@ def flash_firmware(
                 port,
                 "--baud",
                 spec.baud,
+                "--after",
+                "no-reset",
                 "write-flash",
                 "--flash-mode",
                 "dio",
@@ -143,10 +151,22 @@ def flash_firmware(
             os.unlink(blank_otadata)
         except OSError:
             pass
+    if boot_after:
+        boot_app(spec, port)
 
 
-def write_config(spec: Esp32Spec, port: str, config: dict, on_line: OnLine = _noop) -> None:
-    """Build and write the NVS config partition at ``spec.nvs_offset``."""
+def write_config(
+    spec: Esp32Spec,
+    port: str,
+    config: dict,
+    on_line: OnLine = _noop,
+    boot_after: bool = True,
+) -> None:
+    """Build and write the NVS config partition at ``spec.nvs_offset``.
+
+    Does not reset the chip; *boot_after* boots the app afterwards (see
+    :func:`flash_firmware`).
+    """
     on_line(f"Writing {describe_config_part(spec)}")
     nvs_binary = build_nvs_binary(spec, config)
     with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
@@ -161,6 +181,8 @@ def write_config(spec: Esp32Spec, port: str, config: dict, on_line: OnLine = _no
                 port,
                 "--baud",
                 spec.baud,
+                "--after",
+                "no-reset",
                 "write-flash",
                 "--flash-mode",
                 "dio",
@@ -174,6 +196,8 @@ def write_config(spec: Esp32Spec, port: str, config: dict, on_line: OnLine = _no
             os.unlink(tmp_path)
         except OSError:
             pass
+    if boot_after:
+        boot_app(spec, port)
 
 
 def flash_device(
@@ -185,16 +209,27 @@ def flash_device(
 ) -> dict | None:
     """Full provisioning: flash firmware, then write NVS config, then verify.
 
+    The whole sequence runs without resetting the chip, and the app is booted
+    exactly once at the very end. Booting between steps would start a full panel
+    repaint that the next step then interrupts mid-refresh — see
+    :func:`device.boot_app`.
+
     Returns the verified device state (see :func:`device.parse_device_state`),
     or ``None`` if the post-flash read-back failed.
     """
-    flash_firmware(spec, port, firmware_path, on_line)
-    write_config(spec, port, config, on_line)
+    try:
+        flash_firmware(spec, port, firmware_path, on_line, boot_after=False)
+        write_config(spec, port, config, on_line, boot_after=False)
+    except BaseException:
+        # Never leave the screen halted in the flasher stub because a step failed.
+        boot_app(spec, port)
+        raise
 
     on_line(
         f"Verifying: reading back NVS at {hex(spec.nvs_offset)} and the app header of the "
         "slot the device boots..."
     )
+    # read_device_flash boots the app once its reads are done.
     nvs_data, app_header = read_device_flash(spec, port)
     state = parse_device_state(spec, nvs_data, app_header) if app_header is not None else None
     on_line("Done.")

--- a/python/hokku/common/esp32/flasher.py
+++ b/python/hokku/common/esp32/flasher.py
@@ -64,67 +64,89 @@ def _run_esptool(args: list[str], on_line: OnLine) -> None:
         raise EsptoolError(f"esptool exited {proc.returncode} (command: esptool {' '.join(args)})")
 
 
-def erase_otadata(spec: Esp32Spec, port: str, on_line: OnLine = _noop) -> None:
-    """Erase the otadata partition so the bootloader runs the app in ota_0.
+def describe_flash_parts(spec: Esp32Spec, firmware_path: Path) -> list[str]:
+    """One line per flash region :func:`flash_firmware` writes: file, size, offset.
 
-    The merged image covers bootloader + partition table + ota_0 only; it does
-    not include otadata. A device that has taken an OTA has otadata selecting
-    ota_1, so without this it would keep booting the *old* firmware left there
-    and silently ignore everything just written to ota_0. Blanking otadata makes
-    the bootloader fall back to ota_0 — the image we just flashed.
+    Every front end prints these before writing, so an operator can always see
+    which image landed in which partition rather than a bare "flashing...".
     """
-    on_line("Clearing OTA slot selection...")
-    _run_esptool(
-        [
-            "--chip",
-            "esp32s3",
-            "--port",
-            port,
-            "--baud",
-            spec.baud,
-            "erase-region",
-            hex(spec.otadata_offset),
-            hex(spec.otadata_size),
-        ],
-        on_line,
+    fw = Path(firmware_path)
+    try:
+        fw_size = f"{fw.stat().st_size:,} bytes"
+    except OSError:
+        fw_size = "size unknown"
+    return [
+        f"{fw.name} ({fw_size}) -> {hex(spec.bootloader_offset)} "
+        "[bootloader + partition table + app slot ota_0]",
+        f"blank otadata ({spec.otadata_size:,} bytes of 0xFF) -> {hex(spec.otadata_offset)} "
+        "[clears the OTA slot selection so the bootloader runs the image above]",
+    ]
+
+
+def describe_config_part(spec: Esp32Spec) -> str:
+    """What :func:`write_config` writes, and where."""
+    return (
+        f"generated NVS config image ({spec.nvs_size:,} bytes) -> {hex(spec.nvs_offset)} "
+        "[Wi-Fi credentials + server URL + screen name]"
     )
 
 
 def flash_firmware(
     spec: Esp32Spec, port: str, firmware_path: Path, on_line: OnLine = _noop
 ) -> None:
-    """Write the merged firmware image at the bootloader offset (0x0).
+    """Write the merged firmware image and blank otadata, in one esptool pass.
 
-    Followed by :func:`erase_otadata`, without which the freshly written ota_0
-    is not what the device boots (see that function).
+    The merged image covers bootloader + partition table + ota_0 only; it does
+    not include otadata, the record that tells the bootloader which A/B slot to
+    run. A device that has taken an OTA has otadata selecting ota_1, so without
+    blanking it the device keeps booting the *old* firmware left there and
+    silently ignores everything just written to ota_0.
+
+    Blank otadata is simply all-0xFF, so it is written as another region of the
+    same ``write-flash`` rather than a separate ``erase-region`` call — one
+    connect and one reset instead of two. Each extra esptool cycle drops the
+    chip into download mode and hard-resets it, which is worth avoiding: the
+    panel controller does not always survive being reset mid-transaction.
     """
-    on_line(f"Flashing firmware {Path(firmware_path).name} (~30s)...")
-    _run_esptool(
-        [
-            "--chip",
-            "esp32s3",
-            "--port",
-            port,
-            "--baud",
-            spec.baud,
-            "write-flash",
-            "--flash-mode",
-            "dio",
-            "--flash-freq",
-            "80m",
-            "--flash-size",
-            spec.flash_size,
-            hex(spec.bootloader_offset),
-            str(firmware_path),
-        ],
-        on_line,
-    )
-    erase_otadata(spec, port, on_line)
+    for part in describe_flash_parts(spec, firmware_path):
+        on_line(f"Flashing {part}")
+    on_line("(~30s)...")
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+        f.write(b"\xff" * spec.otadata_size)
+        blank_otadata = f.name
+    try:
+        _run_esptool(
+            [
+                "--chip",
+                "esp32s3",
+                "--port",
+                port,
+                "--baud",
+                spec.baud,
+                "write-flash",
+                "--flash-mode",
+                "dio",
+                "--flash-freq",
+                "80m",
+                "--flash-size",
+                spec.flash_size,
+                hex(spec.bootloader_offset),
+                str(firmware_path),
+                hex(spec.otadata_offset),
+                blank_otadata,
+            ],
+            on_line,
+        )
+    finally:
+        try:
+            os.unlink(blank_otadata)
+        except OSError:
+            pass
 
 
 def write_config(spec: Esp32Spec, port: str, config: dict, on_line: OnLine = _noop) -> None:
     """Build and write the NVS config partition at ``spec.nvs_offset``."""
-    on_line("Writing configuration...")
+    on_line(f"Writing {describe_config_part(spec)}")
     nvs_binary = build_nvs_binary(spec, config)
     with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
         f.write(nvs_binary)
@@ -168,7 +190,10 @@ def flash_device(
     flash_firmware(spec, port, firmware_path, on_line)
     write_config(spec, port, config, on_line)
 
-    on_line("Verifying...")
+    on_line(
+        f"Verifying: reading back NVS at {hex(spec.nvs_offset)} and the app header of the "
+        "slot the device boots..."
+    )
     nvs_data, app_header = read_device_flash(spec, port)
     state = parse_device_state(spec, nvs_data, app_header) if app_header is not None else None
     on_line("Done.")

--- a/python/hokku/common/esp32/spec.py
+++ b/python/hokku/common/esp32/spec.py
@@ -28,6 +28,14 @@ class Esp32Spec:
     app_offset: int
     bootloader_offset: int = 0x0
 
+    # A/B OTA layout. ``app_offset`` is ota_0 (where the merged image lands);
+    # ``ota1_offset`` is the slot an OTA writes into, and ``otadata`` selects
+    # which of the two the bootloader runs. Identical on every board so far, but
+    # they come from the model's partitions.csv like the other offsets.
+    ota1_offset: int = 0x310000
+    otadata_offset: int = 0x610000
+    otadata_size: int = 0x2000
+
     # ESP32-S3 USB Serial/JTAG VID:PID (same for every board here).
     vid: int = 0x303A
     pid: int = 0x1001

--- a/python/hokku/screens/bigme_f7/bootstrap.py
+++ b/python/hokku/screens/bigme_f7/bootstrap.py
@@ -315,7 +315,11 @@ def bootstrap_device(
     if img[:4] != b"AWIH":
         raise RuntimeError("bundled image is not an AWIH xr_system.img")
 
-    on_line(f"Bootstrapping Bigme F7 on {port} ({len(img):,} B image).")
+    on_line(f"Bootstrapping Bigme F7 on {port}.")
+    on_line(
+        f"Firmware: {Path(image_path).name} ({len(img):,} bytes) -> slot 0 and its A/B cfg "
+        "sector [slot 1 (OEM) is left untouched]"
+    )
     writer = _LineWriter(on_line)
 
     # Phase A — no-touch software entry (a unit already on Hokku firmware answers
@@ -343,6 +347,7 @@ def bootstrap_device(
     had_existing_cfg = False
     try:
         try:
+            on_line(f"Writing {Path(image_path).name} -> slot 0 (do NOT unplug now)...")
             with contextlib.redirect_stdout(writer):
                 flash_slot0(f, img, reboot=False)
             writer.flush()

--- a/python/hokku/screens/huessen_epf1301/__init__.py
+++ b/python/hokku/screens/huessen_epf1301/__init__.py
@@ -67,6 +67,7 @@ read_device_flash = partial(_device.read_device_flash, SPEC)
 parse_device_state = partial(_device.parse_device_state, SPEC)
 scan_devices = partial(_device.scan_devices, SPEC)
 active_ota_slot = _device.active_ota_slot  # pure otadata parse, takes no spec
+boot_app = partial(_device.boot_app, SPEC)
 
 # Flashing (spec-bound).
 flash_firmware = partial(_flasher.flash_firmware, SPEC)
@@ -86,6 +87,7 @@ __all__ = [
     "NvsToolUnavailable",
     "active_ota_slot",
     "app_image_from_file",
+    "boot_app",
     "build_nvs_binary",
     "bundled_firmware_version",
     "constants",

--- a/python/hokku/screens/huessen_epf1301/__init__.py
+++ b/python/hokku/screens/huessen_epf1301/__init__.py
@@ -33,6 +33,9 @@ SPEC = Esp32Spec(
     nvs_size=constants.NVS_SIZE,
     app_offset=constants.APP_OFFSET,
     bootloader_offset=constants.BOOTLOADER_OFFSET,
+    ota1_offset=constants.OTA1_OFFSET,
+    otadata_offset=constants.OTADATA_OFFSET,
+    otadata_size=constants.OTADATA_SIZE,
     vid=constants.ESP32S3_VID,
     pid=constants.ESP32S3_PID,
     baud=constants.ESPTOOL_BAUD,
@@ -63,9 +66,11 @@ list_serial_ports = partial(_device.list_serial_ports, SPEC)
 read_device_flash = partial(_device.read_device_flash, SPEC)
 parse_device_state = partial(_device.parse_device_state, SPEC)
 scan_devices = partial(_device.scan_devices, SPEC)
+active_ota_slot = _device.active_ota_slot  # pure otadata parse, takes no spec
 
 # Flashing (spec-bound).
 flash_firmware = partial(_flasher.flash_firmware, SPEC)
+erase_otadata = partial(_flasher.erase_otadata, SPEC)
 write_config = partial(_flasher.write_config, SPEC)
 flash_device = partial(_flasher.flash_device, SPEC)
 
@@ -78,10 +83,12 @@ __all__ = [
     "SPEC",
     "EsptoolError",
     "NvsToolUnavailable",
+    "active_ota_slot",
     "app_image_from_file",
     "build_nvs_binary",
     "bundled_firmware_version",
     "constants",
+    "erase_otadata",
     "flash_device",
     "flash_firmware",
     "list_firmware_files",

--- a/python/hokku/screens/huessen_epf1301/__init__.py
+++ b/python/hokku/screens/huessen_epf1301/__init__.py
@@ -70,7 +70,8 @@ active_ota_slot = _device.active_ota_slot  # pure otadata parse, takes no spec
 
 # Flashing (spec-bound).
 flash_firmware = partial(_flasher.flash_firmware, SPEC)
-erase_otadata = partial(_flasher.erase_otadata, SPEC)
+describe_flash_parts = partial(_flasher.describe_flash_parts, SPEC)
+describe_config_part = partial(_flasher.describe_config_part, SPEC)
 write_config = partial(_flasher.write_config, SPEC)
 flash_device = partial(_flasher.flash_device, SPEC)
 
@@ -88,7 +89,8 @@ __all__ = [
     "build_nvs_binary",
     "bundled_firmware_version",
     "constants",
-    "erase_otadata",
+    "describe_config_part",
+    "describe_flash_parts",
     "flash_device",
     "flash_firmware",
     "list_firmware_files",

--- a/python/hokku/screens/huessen_epf1301/constants.py
+++ b/python/hokku/screens/huessen_epf1301/constants.py
@@ -39,6 +39,14 @@ CONFIG_VERSION = 2
 BOOTLOADER_OFFSET = 0x0
 APP_OFFSET = 0x10000
 
+# A/B OTA partitions (see firmware/huessen_epf1301/partitions.csv). The merged
+# image only covers ota_0; otadata selects which slot the bootloader runs, so a
+# USB flash must clear it (blank otadata -> ota_0) or the device keeps booting
+# whatever an earlier OTA left in ota_1.
+OTA1_OFFSET = 0x310000
+OTADATA_OFFSET = 0x610000
+OTADATA_SIZE = 0x2000
+
 # esptool --flash-size for this board (16 MB flash).
 FLASH_SIZE = "16MB"
 

--- a/python/hokku/screens/seeedstudio_e1004/__init__.py
+++ b/python/hokku/screens/seeedstudio_e1004/__init__.py
@@ -34,6 +34,9 @@ SPEC = Esp32Spec(
     nvs_size=constants.NVS_SIZE,
     app_offset=constants.APP_OFFSET,
     bootloader_offset=constants.BOOTLOADER_OFFSET,
+    ota1_offset=constants.OTA1_OFFSET,
+    otadata_offset=constants.OTADATA_OFFSET,
+    otadata_size=constants.OTADATA_SIZE,
     vid=constants.ESP32S3_VID,
     pid=constants.ESP32S3_PID,
     baud=constants.ESPTOOL_BAUD,
@@ -64,9 +67,11 @@ list_serial_ports = partial(_device.list_serial_ports, SPEC)
 read_device_flash = partial(_device.read_device_flash, SPEC)
 parse_device_state = partial(_device.parse_device_state, SPEC)
 scan_devices = partial(_device.scan_devices, SPEC)
+active_ota_slot = _device.active_ota_slot  # pure otadata parse, takes no spec
 
 # Flashing (spec-bound).
 flash_firmware = partial(_flasher.flash_firmware, SPEC)
+erase_otadata = partial(_flasher.erase_otadata, SPEC)
 write_config = partial(_flasher.write_config, SPEC)
 flash_device = partial(_flasher.flash_device, SPEC)
 
@@ -80,10 +85,12 @@ __all__ = [
     "EsptoolError",
     "NvsToolUnavailable",
     "SeeedstudioE1004Display",
+    "active_ota_slot",
     "app_image_from_file",
     "build_nvs_binary",
     "bundled_firmware_version",
     "constants",
+    "erase_otadata",
     "flash_device",
     "flash_firmware",
     "list_firmware_files",

--- a/python/hokku/screens/seeedstudio_e1004/__init__.py
+++ b/python/hokku/screens/seeedstudio_e1004/__init__.py
@@ -68,6 +68,7 @@ read_device_flash = partial(_device.read_device_flash, SPEC)
 parse_device_state = partial(_device.parse_device_state, SPEC)
 scan_devices = partial(_device.scan_devices, SPEC)
 active_ota_slot = _device.active_ota_slot  # pure otadata parse, takes no spec
+boot_app = partial(_device.boot_app, SPEC)
 
 # Flashing (spec-bound).
 flash_firmware = partial(_flasher.flash_firmware, SPEC)
@@ -88,6 +89,7 @@ __all__ = [
     "SeeedstudioE1004Display",
     "active_ota_slot",
     "app_image_from_file",
+    "boot_app",
     "build_nvs_binary",
     "bundled_firmware_version",
     "constants",

--- a/python/hokku/screens/seeedstudio_e1004/__init__.py
+++ b/python/hokku/screens/seeedstudio_e1004/__init__.py
@@ -71,7 +71,8 @@ active_ota_slot = _device.active_ota_slot  # pure otadata parse, takes no spec
 
 # Flashing (spec-bound).
 flash_firmware = partial(_flasher.flash_firmware, SPEC)
-erase_otadata = partial(_flasher.erase_otadata, SPEC)
+describe_flash_parts = partial(_flasher.describe_flash_parts, SPEC)
+describe_config_part = partial(_flasher.describe_config_part, SPEC)
 write_config = partial(_flasher.write_config, SPEC)
 flash_device = partial(_flasher.flash_device, SPEC)
 
@@ -90,7 +91,8 @@ __all__ = [
     "build_nvs_binary",
     "bundled_firmware_version",
     "constants",
-    "erase_otadata",
+    "describe_config_part",
+    "describe_flash_parts",
     "flash_device",
     "flash_firmware",
     "list_firmware_files",

--- a/python/hokku/screens/seeedstudio_e1004/constants.py
+++ b/python/hokku/screens/seeedstudio_e1004/constants.py
@@ -35,6 +35,14 @@ CONFIG_VERSION = 2
 BOOTLOADER_OFFSET = 0x0
 APP_OFFSET = 0x10000
 
+# A/B OTA partitions (see firmware/seeedstudio_e1004/partitions.csv). The merged
+# image only covers ota_0; otadata selects which slot the bootloader runs, so a
+# USB flash must clear it (blank otadata -> ota_0) or the device keeps booting
+# whatever an earlier OTA left in ota_1.
+OTA1_OFFSET = 0x310000
+OTADATA_OFFSET = 0x610000
+OTADATA_SIZE = 0x2000
+
 # esptool --flash-size for this board (32 MB flash — the E1004's ESP32-S3R8).
 FLASH_SIZE = "32MB"
 

--- a/python/hokku/webserver/flashing.py
+++ b/python/hokku/webserver/flashing.py
@@ -22,6 +22,12 @@ logger = logging.getLogger(__name__)
 
 _job_ids = itertools.count(1)
 
+# How long a scanned screen may sit in the bootloader waiting for the flash that
+# usually follows. Long enough to fill in the flash form, short enough that a scan
+# the operator then abandons does not leave the screen unable to update. The panel
+# keeps displaying its last image throughout — e-paper holds without power.
+DEFERRED_BOOT_SECONDS = 300.0
+
 
 class FlashJobManager:
     """Owns at most one in-flight flash job."""
@@ -34,6 +40,55 @@ class FlashJobManager:
         # thread, no log). It must still hold the single slot so a flash cannot
         # start mid-scan and have two esptools fight over one device.
         self._scanning = False
+        # Pending "boot the screen back into its firmware" timers, by port.
+        self._boot_timers: dict[str, threading.Timer] = {}
+
+    def arm_deferred_boot(
+        self, screen, ports: list[str], delay: float = DEFERRED_BOOT_SECONDS
+    ) -> None:
+        """Boot *ports* back into firmware after *delay*, unless a flash starts.
+
+        A scan deliberately leaves the device halted in the bootloader: booting it
+        would start a full panel repaint (~30-60s) at exactly the moment the
+        operator is about to flash, and the flash would interrupt that paint
+        mid-refresh and wedge the panel controller. Since a scan is not always
+        followed by a flash, this is the safety net that puts the screen back to
+        work on its own.
+        """
+        for port in ports:
+            self._cancel_deferred_boot(port)
+            timer = threading.Timer(delay, self._deferred_boot, args=(screen, port))
+            timer.daemon = True
+            with self._lock:
+                self._boot_timers[port] = timer
+            timer.start()
+
+    def _cancel_deferred_boot(self, port: str | None = None) -> None:
+        """Drop pending boot timers — for *port*, or all of them when None."""
+        with self._lock:
+            ports = [port] if port is not None else list(self._boot_timers)
+            timers = [self._boot_timers.pop(p) for p in ports if p in self._boot_timers]
+        for t in timers:
+            t.cancel()
+
+    def _deferred_boot(self, screen, port: str) -> None:
+        """Timer callback: boot the screen if the serial port is free.
+
+        If a flash is running it owns the port and will boot the device itself,
+        so this simply steps aside.
+        """
+        with self._lock:
+            self._boot_timers.pop(port, None)
+        if not self.begin_scan():
+            logger.info("Deferred boot for %s skipped: the serial port is busy", port)
+            return
+        try:
+            logger.info("Scan was not followed by a flash — booting %s back into firmware", port)
+            screen.boot_app(port)
+        except Exception as e:  # a best-effort recovery must never raise into a timer
+            logger.warning("Deferred boot for %s failed: %s", port, e)
+        finally:
+            self.end_scan()
 
     def _slot_taken(self) -> bool:
         """Whether the single serial slot is held (caller must hold ``_lock``)."""
@@ -59,6 +114,9 @@ class FlashJobManager:
     def _new_job(self, port: str, kind: str, screen_model: str | None = None) -> dict | None:
         """Create the single in-flight job (caller holds no lock). Returns the job
         dict, or ``None`` if the serial slot is already taken (flash or scan)."""
+        # The flash is what the scan was holding the device in the bootloader for,
+        # and it boots the screen itself when it finishes.
+        self._cancel_deferred_boot(port)
         with self._lock:
             if self._slot_taken():
                 return None

--- a/python/hokku/webserver/flask_app.py
+++ b/python/hokku/webserver/flask_app.py
@@ -1196,9 +1196,18 @@ def create_app(
             return jsonify({"error": "a flash is in progress", "busy": True}), 409
         try:
             screen = esp32_screen(request.args.get("model")) or huessen_epf1301
-            devices = screen.scan_devices()
+            # Leave the scanned screens in the bootloader. Booting one starts a
+            # full panel repaint (~30-60s), and a scan is nearly always the step
+            # right before a flash — which would then interrupt that paint
+            # mid-refresh and wedge the panel controller. The panel keeps showing
+            # its last image meanwhile (e-paper holds without power), and
+            # arm_deferred_boot puts it back to work if no flash follows.
+            devices = screen.scan_devices(boot_after=False)
         finally:
             state.flash_jobs.end_scan()
+        state.flash_jobs.arm_deferred_boot(
+            screen, [d["port"] for d in devices if d.get("is_esp32")]
+        )
         # Classify non-ESP32 ports the UI knows how to guide: a CH340 bridge is a
         # Bigme F7 (XR872), which is USB-flashed by a different (vendor-tool)
         # procedure, not esptool — so the UI shows F7 guidance instead of the

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hokku-server"
-version = "4.0.1.dev10"
+version = "4.0.1.dev11"
 description = "Spectra 6 e-ink image server for Hokku EL133UF1 display"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hokku-server"
-version = "4.0.1.dev9"
+version = "4.0.1.dev10"
 description = "Spectra 6 e-ink image server for Hokku EL133UF1 display"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hokku-server"
-version = "4.0.1.dev8"
+version = "4.0.1.dev9"
 description = "Spectra 6 e-ink image server for Hokku EL133UF1 display"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hokku-server"
-version = "4.0.1.dev13"
+version = "4.0.1.dev8"
 description = "Spectra 6 e-ink image server for Hokku EL133UF1 display"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/tests/test_flash_common.py
+++ b/python/tests/test_flash_common.py
@@ -111,6 +111,43 @@ def test_job_manager_runs_and_streams(monkeypatch):
     assert st["finished_at"] is not None
 
 
+class _FakeScreen:
+    """Minimal stand-in exposing just the boot_app the deferred boot calls."""
+
+    def __init__(self):
+        self.booted: list[str] = []
+
+    def boot_app(self, port):
+        self.booted.append(port)
+        return True
+
+
+def test_deferred_boot_restarts_a_screen_a_scan_left_in_the_bootloader():
+    """A scan holds the screen in the bootloader so the flash that usually follows
+    cannot interrupt a panel repaint. If no flash comes, it must still recover."""
+    mgr = flashing.FlashJobManager()
+    screen = _FakeScreen()
+    mgr.arm_deferred_boot(screen, ["COM9"], delay=0.05)
+    _wait_until(lambda: screen.booted == ["COM9"])
+    assert screen.booted == ["COM9"]
+
+
+def test_starting_a_flash_cancels_the_deferred_boot(monkeypatch):
+    """The flash is what the hold was for, and it boots the screen itself."""
+
+    def fake_flash(port, config, firmware_path, on_line):
+        return {"config_version_ok": True}
+
+    monkeypatch.setattr(huessen_epf1301, "flash_device", fake_flash)
+    mgr = flashing.FlashJobManager()
+    screen = _FakeScreen()
+    mgr.arm_deferred_boot(screen, ["COM9"], delay=0.2)
+    assert mgr.start("COM9", {}, Path("fw.bin")) is not None
+    _wait_until(lambda: (mgr.status() or {}).get("state") != "running")
+    time.sleep(0.4)  # past when the timer would have fired
+    assert screen.booted == [], "the flash owns the boot; the timer must not fire"
+
+
 def test_job_manager_dispatches_by_model(monkeypatch):
     """start(screen_model=...) routes to that screen's flash_device (its spec)."""
     calls: list[str] = []
@@ -378,7 +415,7 @@ def test_flash_devices_allowed_when_only_seeed_has_firmware(app_config, tmp_path
     seeed_fw.write_bytes(b"\x00")
     monkeypatch.setattr(huessen_epf1301, "merged_firmware_file", lambda *a, **k: None)
     monkeypatch.setattr(seeedstudio_e1004, "merged_firmware_file", lambda *a, **k: seeed_fw)
-    monkeypatch.setattr(huessen_epf1301, "scan_devices", lambda: [])
+    monkeypatch.setattr(huessen_epf1301, "scan_devices", lambda **k: [])
     client = _client(_bare_state(app_config), tmp_path)
     assert client.get("/hokku/api/flash/devices").status_code == 200
 
@@ -484,7 +521,7 @@ def test_flash_devices_classifies_bigme_f7(app_config, tmp_path, monkeypatch):
     monkeypatch.setattr(
         huessen_epf1301,
         "scan_devices",
-        lambda: [
+        lambda **k: [
             {
                 "port": "COM7",
                 "description": "USB-SERIAL CH340",

--- a/python/tests/test_flash_esp32.py
+++ b/python/tests/test_flash_esp32.py
@@ -15,10 +15,14 @@ esp-idf-nvs-partition-gen subprocess and is skipped if it is not installed.
 from __future__ import annotations
 
 import json
+import struct
+import zlib
 from pathlib import Path
 
 import pytest
 
+from hokku.common.esp32 import device as esp32_device
+from hokku.common.esp32 import flasher as esp32_flasher
 from hokku.common.esp32 import nvs as esp32_nvs
 from hokku.screens import huessen_epf1301, seeedstudio_e1004
 from hokku.webserver.app_config import AppConfig
@@ -105,6 +109,118 @@ def test_parse_device_state_reads_config(esp32_mod):
     state = esp32_mod.parse_device_state(nvs, _make_app_header())
     assert state["config_version_ok"] is True
     assert state["config"]["screen_name"] == "Den"
+
+
+# ── esp32.device: which OTA slot the device actually boots ────────────────────
+
+
+def _ota_select_entry(seq: int) -> bytes:
+    """One 32-byte ``esp_ota_select_entry_t`` carrying a valid CRC."""
+    entry = bytearray(32)
+    struct.pack_into("<I", entry, 0, seq)
+    struct.pack_into("<I", entry, 28, zlib.crc32(struct.pack("<I", seq), 0xFFFFFFFF) & 0xFFFFFFFF)
+    return bytes(entry)
+
+
+def _otadata(seq0: int | None, seq1: int | None) -> bytes:
+    """An 8 KB otadata partition; the two entries sit one 4 KB sector apart."""
+    blob = bytearray(b"\xff" * 0x2000)
+    if seq0 is not None:
+        blob[0:32] = _ota_select_entry(seq0)
+    if seq1 is not None:
+        blob[0x1000:0x1020] = _ota_select_entry(seq1)
+    return bytes(blob)
+
+
+def test_active_ota_slot_blank_otadata_boots_ota0(esp32_mod):
+    # What a USB flash leaves behind — erased otadata means the bootloader runs
+    # ota_0, which is the only slot the merged image covers.
+    assert esp32_mod.active_ota_slot(b"\xff" * 0x2000) == 0
+    assert esp32_mod.active_ota_slot(None) == 0
+
+
+def test_active_ota_slot_highest_seq_wins(esp32_mod):
+    # seq 7/8 are the real values read off a screen that had taken an OTA; it
+    # was booting ota_1 while ota_0 held freshly flashed (ignored) firmware.
+    assert esp32_mod.active_ota_slot(_otadata(7, 8)) == 1
+    assert esp32_mod.active_ota_slot(_otadata(9, 8)) == 0
+    assert esp32_mod.active_ota_slot(_otadata(None, 8)) == 1
+
+
+def test_active_ota_slot_ignores_crc_invalid_entry(esp32_mod):
+    blob = bytearray(_otadata(7, 8))
+    struct.pack_into("<I", blob, 0x1000 + 28, 0xDEADBEEF)  # corrupt entry 1's CRC
+    # Entry 1 is discarded like the bootloader would, leaving seq 7 -> ota_0.
+    assert esp32_mod.active_ota_slot(bytes(blob)) == 0
+
+
+def _first_read_blob(spec, nvs_bytes: bytes, ota0_header: bytes) -> bytes:
+    """The nvs..ota_0-header span that ``read_device_flash`` slices up."""
+    blob = bytearray(b"\x00" * (spec.app_offset - spec.nvs_offset))
+    blob[: len(nvs_bytes)] = nvs_bytes
+    return bytes(blob) + ota0_header
+
+
+def test_read_device_flash_reports_the_booting_slot(esp32_mod, monkeypatch):
+    """With otadata selecting ota_1, the version must come from ota_1.
+
+    Reading ota_0 unconditionally is what let a stale screen report the version
+    that had just been flashed into the slot it was not booting.
+    """
+    spec = esp32_mod.SPEC
+    ota0 = _make_app_header(b"20260726000000Z")  # freshly flashed, not booted
+    ota1 = _make_app_header(b"20260101000000Z")  # older, actually running
+
+    def fake_read(_spec, _port, offset, _size, _timeout):
+        if offset == spec.nvs_offset:
+            return _first_read_blob(spec, b"\x00" * spec.nvs_size, ota0)
+        if offset == spec.otadata_offset:
+            return _otadata(7, 8)  # -> ota_1
+        if offset == spec.ota1_offset:
+            return ota1
+        raise AssertionError(f"unexpected read at {offset:#x}")
+
+    monkeypatch.setattr(esp32_device, "_read_region", fake_read)
+    _nvs, header = esp32_mod.read_device_flash("/dev/null")
+    assert esp32_device._version_from_header(header) == "20260101000000Z"
+
+
+def test_read_device_flash_uses_ota0_when_otadata_blank(esp32_mod, monkeypatch):
+    spec = esp32_mod.SPEC
+    ota0 = _make_app_header(b"20260726000000Z")
+
+    def fake_read(_spec, _port, offset, _size, _timeout):
+        if offset == spec.nvs_offset:
+            return _first_read_blob(spec, b"\x00" * spec.nvs_size, ota0)
+        if offset == spec.otadata_offset:
+            return b"\xff" * spec.otadata_size
+        raise AssertionError(f"ota_1 must not be read when otadata is blank ({offset:#x})")
+
+    monkeypatch.setattr(esp32_device, "_read_region", fake_read)
+    _nvs, header = esp32_mod.read_device_flash("/dev/null")
+    assert esp32_device._version_from_header(header) == "20260726000000Z"
+
+
+# ── esp32.flasher: a USB flash must reselect ota_0 ────────────────────────────
+
+
+def test_flash_firmware_clears_otadata(esp32_mod, tmp_path, monkeypatch):
+    """Without this the bootloader keeps running whatever an OTA left in ota_1,
+    so the flash appears to succeed while the old firmware stays live."""
+    calls = []
+    monkeypatch.setattr(esp32_flasher, "_run_esptool", lambda args, on_line: calls.append(args))
+    img = tmp_path / "hokku-fw-1.2.3.bin"
+    img.write_bytes(b"\xe9")
+    esp32_mod.flash_firmware("/dev/null", img)
+
+    assert len(calls) == 2, "expected write-flash then erase-region"
+    assert "write-flash" in calls[0]
+    erase = calls[1]
+    assert "erase-region" in erase
+    at = erase.index("erase-region")
+    spec = esp32_mod.SPEC
+    assert erase[at + 1] == hex(spec.otadata_offset)
+    assert erase[at + 2] == hex(spec.otadata_size)
 
 
 # ── esp32.firmware: merged-file discovery + app-image slice ────────────────────

--- a/python/tests/test_flash_esp32.py
+++ b/python/tests/test_flash_esp32.py
@@ -32,6 +32,16 @@ from hokku.webserver.image_classifier import ImageClassifier
 from hokku.webserver.serve_scheduler import ServeScheduler
 
 
+@pytest.fixture(autouse=True)
+def _never_touch_real_hardware(monkeypatch):
+    """Keep the suite hardware-free: boot_app would otherwise shell out to esptool.
+
+    Patched in both namespaces — flasher imports the symbol directly.
+    """
+    monkeypatch.setattr(esp32_device, "boot_app", lambda *a, **k: True)
+    monkeypatch.setattr(esp32_flasher, "boot_app", lambda *a, **k: True)
+
+
 def _make_app_header(version: bytes = b"20260101000000Z") -> bytes:
     """A 256-byte app header with the version string at bytes 48:80."""
     header = bytearray(256)
@@ -264,6 +274,49 @@ def test_describe_config_part_names_size_and_offset(esp32_mod):
     described = esp32_mod.describe_config_part()
     assert f"{spec.nvs_size:,} bytes" in described
     assert hex(spec.nvs_offset) in described
+
+
+def test_flash_device_never_resets_between_steps(esp32_mod, tmp_path, monkeypatch):
+    """A reset boots the app, and a boot starts a full ~28s panel repaint that the
+    next flash step then interrupts mid-refresh, wedging the panel controller. So
+    every step runs --after no-reset and the app is booted exactly once, at the end.
+    """
+    calls = []
+    boots = []
+    monkeypatch.setattr(esp32_flasher, "_run_esptool", lambda args, on_line: calls.append(args))
+    monkeypatch.setattr(esp32_flasher, "boot_app", lambda *a, **k: boots.append("boot") or True)
+    monkeypatch.setattr(esp32_device, "boot_app", lambda *a, **k: boots.append("boot") or True)
+    monkeypatch.setattr(esp32_device, "_read_region", lambda *a, **k: None)
+    monkeypatch.setattr(
+        esp32_flasher, "build_nvs_binary", lambda spec, cfg: b"\x00" * spec.nvs_size
+    )
+    img = tmp_path / "hokku-fw-1.2.3.bin"
+    img.write_bytes(b"\xe9" * 64)
+
+    esp32_mod.flash_device("/dev/null", {"wifi_ssid1": "n", "image_url": "u"}, img)
+
+    assert calls, "expected esptool writes"
+    for args in calls:
+        assert "--after" in args, f"no reset policy given: {args}"
+        assert args[args.index("--after") + 1] == "no-reset"
+    assert len(boots) == 1, f"the app must boot exactly once, got {len(boots)}"
+
+
+def test_flash_device_boots_the_app_even_if_a_step_fails(esp32_mod, tmp_path, monkeypatch):
+    """A failed step must not strand the screen halted in the flasher stub."""
+    boots = []
+
+    def boom(_args, _on_line):
+        raise esp32_flasher.EsptoolError("write failed")
+
+    monkeypatch.setattr(esp32_flasher, "_run_esptool", boom)
+    monkeypatch.setattr(esp32_flasher, "boot_app", lambda *a, **k: boots.append("boot") or True)
+    img = tmp_path / "hokku-fw-1.2.3.bin"
+    img.write_bytes(b"\xe9" * 64)
+
+    with pytest.raises(esp32_flasher.EsptoolError):
+        esp32_mod.flash_device("/dev/null", {"wifi_ssid1": "n", "image_url": "u"}, img)
+    assert boots == ["boot"]
 
 
 def test_flash_firmware_announces_every_region_before_writing(esp32_mod, tmp_path, monkeypatch):

--- a/python/tests/test_flash_esp32.py
+++ b/python/tests/test_flash_esp32.py
@@ -204,23 +204,81 @@ def test_read_device_flash_uses_ota0_when_otadata_blank(esp32_mod, monkeypatch):
 # ── esp32.flasher: a USB flash must reselect ota_0 ────────────────────────────
 
 
-def test_flash_firmware_clears_otadata(esp32_mod, tmp_path, monkeypatch):
-    """Without this the bootloader keeps running whatever an OTA left in ota_1,
-    so the flash appears to succeed while the old firmware stays live."""
+def _fake_esptool(monkeypatch, calls):
+    """Capture esptool argv and the temp file contents, which vanish on return."""
+
+    def run(args, _on_line):
+        snapshot = list(args)
+        payloads = {}
+        for i, a in enumerate(args[:-1]):
+            if isinstance(a, str) and a.startswith("0x"):
+                path = Path(args[i + 1])
+                if path.exists():
+                    payloads[a] = path.read_bytes()
+        calls.append((snapshot, payloads))
+
+    monkeypatch.setattr(esp32_flasher, "_run_esptool", run)
+
+
+def test_flash_firmware_blanks_otadata_in_the_same_pass(esp32_mod, tmp_path, monkeypatch):
+    """Without blanking otadata the bootloader keeps running whatever an OTA left
+    in ota_1, so the flash appears to succeed while the old firmware stays live.
+
+    It rides along in the firmware write rather than a second esptool call: each
+    extra invocation drops the chip into download mode and hard-resets it.
+    """
     calls = []
-    monkeypatch.setattr(esp32_flasher, "_run_esptool", lambda args, on_line: calls.append(args))
+    _fake_esptool(monkeypatch, calls)
     img = tmp_path / "hokku-fw-1.2.3.bin"
-    img.write_bytes(b"\xe9")
+    img.write_bytes(b"\xe9" * 64)
     esp32_mod.flash_firmware("/dev/null", img)
 
-    assert len(calls) == 2, "expected write-flash then erase-region"
-    assert "write-flash" in calls[0]
-    erase = calls[1]
-    assert "erase-region" in erase
-    at = erase.index("erase-region")
+    assert len(calls) == 1, "firmware + otadata must be one esptool pass"
+    args, payloads = calls[0]
     spec = esp32_mod.SPEC
-    assert erase[at + 1] == hex(spec.otadata_offset)
-    assert erase[at + 2] == hex(spec.otadata_size)
+    assert "write-flash" in args
+    assert args[args.index(hex(spec.bootloader_offset)) + 1] == str(img)
+    # Blank otadata is all-0xFF — what an erase leaves behind.
+    assert payloads[hex(spec.otadata_offset)] == b"\xff" * spec.otadata_size
+
+
+# ── every flashing front end names the file and region it writes ──────────────
+
+
+def test_describe_flash_parts_names_file_size_and_offset(esp32_mod, tmp_path):
+    img = tmp_path / "hokku-fw-9.9.9.bin"
+    img.write_bytes(b"\xe9" * 4096)
+    parts = esp32_mod.describe_flash_parts(img)
+    spec = esp32_mod.SPEC
+
+    joined = "\n".join(parts)
+    assert "hokku-fw-9.9.9.bin" in joined
+    assert "4,096 bytes" in joined
+    assert hex(spec.bootloader_offset) in joined
+    assert hex(spec.otadata_offset) in joined
+    assert "otadata" in joined
+
+
+def test_describe_config_part_names_size_and_offset(esp32_mod):
+    spec = esp32_mod.SPEC
+    described = esp32_mod.describe_config_part()
+    assert f"{spec.nvs_size:,} bytes" in described
+    assert hex(spec.nvs_offset) in described
+
+
+def test_flash_firmware_announces_every_region_before_writing(esp32_mod, tmp_path, monkeypatch):
+    """The rule: a flasher always says which file goes to which region."""
+    monkeypatch.setattr(esp32_flasher, "_run_esptool", lambda args, on_line: None)
+    img = tmp_path / "hokku-fw-1.2.3.bin"
+    img.write_bytes(b"\xe9" * 128)
+    lines = []
+    esp32_mod.flash_firmware("/dev/null", img, on_line=lines.append)
+
+    spec = esp32_mod.SPEC
+    joined = "\n".join(lines)
+    assert "hokku-fw-1.2.3.bin" in joined
+    assert hex(spec.bootloader_offset) in joined
+    assert hex(spec.otadata_offset) in joined
 
 
 # ── esp32.firmware: merged-file discovery + app-image slice ────────────────────

--- a/tools/esp32_setup.py
+++ b/tools/esp32_setup.py
@@ -578,9 +578,11 @@ def _pi_config_mismatch(existing_config, pi_credentials):
 
 
 def write_config(port, config):
-    print("  Writing configuration...", end=" ", flush=True)
+    # esptool's own chatter stays suppressed (on_line defaults to noop), but the
+    # region being written is always named — same facts the web UI shows.
+    print(f"  Writing {SCREEN.describe_config_part()}", end=" ", flush=True)
     try:
-        SCREEN.write_config(port, config)  # on_line defaults to noop — keep CLI quiet
+        SCREEN.write_config(port, config)
         print("done.")
         return True
     except Exception as e:
@@ -599,6 +601,7 @@ def flash_firmware(port):
         return False
 
     try:
+        # flash_firmware names every region it writes via on_line before writing.
         SCREEN.flash_firmware(port, merged, on_line=lambda ln: print(f"    {ln}"))
         print("  Firmware flashed successfully.")
         return True


### PR DESCRIPTION
Flashing a screen over USB could leave it running its **old** firmware, while the
GUI reported the flash as successful and showed the new version. Found on a bench
unit that had taken an OTA: it reported `1.2.19` over serial and `1.2.18` over
HTTP at the same time.

## The bug

The merged firmware image is bootloader + partition table + **`ota_0` only** — it
does not include `otadata`, the record telling the bootloader which A/B slot to
run. A screen that has taken an OTA has `otadata` selecting `ota_1`, so a USB
flash wrote the new firmware into a slot the bootloader was ignoring.

Read off the affected device:

```
otadata @0x610000:  entry0 seq=7   entry1 seq=8   -> boots ota_1
ota_0 @0x10000  ->  1.2.19    (just flashed)
ota_1 @0x310000 ->  1.2.18    (actually booting)
```

The scan hid it: `_version_from_header` read the app header at `app_offset`
(`ota_0`) regardless of which slot was active, so it reported the version just
written rather than the one running — and derived `firmware_current` from it.
This also misreports in normal OTA steady state, where the device runs `ota_1`.

## Fixes

1. **Blank `otadata` on flash** so the bootloader runs the slot just written. It
   rides along as a second region of the same `write-flash` (blank otadata is
   all-`0xFF`), not a separate `erase-region`.
2. **Report the booting slot.** The scan reads `otadata` and resolves the active
   slot the way the IDF bootloader does — highest valid `ota_seq` wins,
   CRC-checked, blank falls back to `ota_0`. The CRC formula was verified against
   real otadata bytes rather than taken from docs.
3. **Never reset between flash steps.** A reset boots the app, and a boot
   repaints the panel (~30s), so every step started a paint that the next step
   interrupted a second or two in. That left the panel controller wedged holding
   BUSY, so the next paint burned its 60s timeout on every wait — a ~6 minute
   paint with a half-rendered image on the glass. All steps now run
   `--after no-reset`, and the app boots exactly once via `esptool run`.
4. **A scan no longer starts a refresh.** Scanning left the screen running, so
   merely looking for a device to flash began a refresh right before the flash
   interrupted it. The scan now leaves the screen in its bootloader — which is
   what the flash wants anyway, and costs nothing visually because e-paper holds
   its image without power. If no flash follows within five minutes the server
   boots the screen back into firmware itself.
5. **Every flash names what it writes.** Each region — firmware file and size to
   `0x0`, the blank `otadata`, the generated NVS config image — with its
   destination offset, in both the web page and the `tools/` CLI. Recorded as a
   standing rule in AGENTS.md. The F7 bootstrap names its image and slot too.

## Verification

Confirmed on hardware (huessen bench unit, Pi appliance) across three deploys.
Before/after on the same wedged screen:

| | before | after |
|---|---|---|
| `device_version` | `1.2.19` (wrong) | `1.2.18` (correct) |
| `firmware_current` | `true` (wrong) | `false` (correct) |

After the fixes: one boot per flash, one clean ~28s paint
(`DRF done (18909ms)`), no BUSY timeouts, and the screen boots the firmware that
was actually written.

801 tests pass; ruff and pyright clean. New tests cover slot resolution
(including a CRC-invalid entry), the scan reading the booting slot, single-pass
otadata blanking, no-reset on every step with exactly one boot, the boot-on-
failure path, the deferred boot, and that a flash cancels it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)