### PR TITLE
docs(agents): derive the dev-version N from main's declared version, not a commit count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,13 +93,31 @@ Versions follow semantic versioning with an even/odd PATCH convention:
 Dev version formula (run before every `git push`):
 ```
 LAST_TAG  = git describe --tags --match "v[0-9]*" --abbrev=0
-MAJOR, MINOR, PATCH = parse LAST_TAG (strip leading v, split on .)
+MAJOR, MINOR, PATCH = parse LAST_TAG (strip leading v, split on ., drop any
+                      prerelease suffix — v4.0.0-beta1 gives PATCH = 0, not "0-beta1")
 ODD_PATCH = PATCH + 1
-N         = git rev-list LAST_TAG..HEAD --count
+CUR       = the dev number currently declared on origin/main, i.e. read
+            `version = "..."` from python/pyproject.toml at origin/main and take
+            the digits after `.dev` (no `.dev` there yet -> CUR = 0)
+N         = CUR + 1
 DEV_VER   = MAJOR.MINOR.ODD_PATCH-dev.N   (semver, e.g. 3.0.1-dev.47)
 DEB_VER   = MAJOR.MINOR.ODD_PATCH~dev.N-1 (Debian, e.g. 3.0.1~dev.47-1)
 PEP_VER   = MAJOR.MINOR.ODD_PATCH.devN    (PEP 440, e.g. 3.0.1.dev47)
 ```
+
+**N comes from main's declared version, NOT from a commit count.** It used to be
+`git rev-list LAST_TAG..HEAD --count`, which regresses as soon as PRs are
+squash-merged: a branch counts its own commits, but the squash lands on main as
+one, so main's count sits well below the number the last merged branch declared.
+The next branch then computes a *lower* N than main already has, and apt stops
+seeing an upgrade — the whole point of the scheme. (Observed 2026-07-28: main
+declared `4.0.1.dev11` while its own rev-list count was 7, so a 2-commit branch
+computed `dev.9` and would have gone backwards.) Deriving N from main's declared
+number is monotonic by construction.
+
+If two branches are open at once they will compute the same N; the second to
+merge must recompute against the new main after merging it in, exactly as it
+would re-resolve any other conflict in these files.
 
 Before every `git push`, agents MUST:
 1. Compute the dev version using the formula above

--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,3 +1,11 @@
+hokku-server (4.0.1~dev.13-1) unstable; urgency=medium
+
+  * docs(agents): derive the dev-version N from main's declared version rather
+    than a commit count. The old rev-list formula regressed as soon as PRs were
+    squash-merged, so apt could stop seeing an upgrade.
+
+ -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Tue, 28 Jul 2026 22:27:13 -0500
+
 hokku-server (4.0.1~dev.12-1) unstable; urgency=medium
 
   * docs(bigme_f7): record two measured hardware findings — the power button

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hokku-server"
-version = "4.0.1.dev12"
+version = "4.0.1.dev13"
 description = "Spectra 6 e-ink image server for Hokku EL133UF1 display"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
The `N = git rev-list LAST_TAG..HEAD --count` rule in AGENTS.md regresses as soon as PRs are squash-merged.

A branch counts its own commits since the tag, but the squash lands on `main` as a single commit — so `main`'s own count sits well below the number the last merged branch declared. The next branch then computes a **lower** N than main already has, and apt stops treating the build as an upgrade, which is the one thing the scheme exists to guarantee.

Hit this on #31 earlier today: `main` declared `4.0.1.dev11` while its own rev-list count was **7**, so a two-commit branch computed `dev.9`. I had to override it by hand to `dev.12` to avoid shipping a version that went backwards.

## Change

N is now `CUR + 1`, where `CUR` is the dev number declared in `python/pyproject.toml` on `origin/main`. Monotonic by construction, and it needs no history archaeology.

Two smaller fixes to the same block:

- **Prerelease suffix.** "parse LAST_TAG (strip leading v, split on .)" gives `PATCH = "0-beta1"` for the current tag `v4.0.0-beta1`. Now says to drop the prerelease suffix.
- **Concurrent branches.** Two open branches compute the same N; spelled out that the second to merge recomputes against the new main, the same as any other conflict in these files.

Applied to itself: main declares `dev.12`, so this is `dev.13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
