### PR TITLE
Remember the flash Wi-Fi credentials for the Bigme F7 form too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@
   images for their model before being admitted. New config keys:
   `firmware_github_repo`, `firmware_dir`.
 
+### Changed
+
+- **The Bigme F7 bootstrap form now remembers the Wi-Fi credentials**, like the
+  ESP32 flash form already did — every screen you provision joins the same
+  network, so the SSID and password now pre-fill from the last flash of *either*
+  kind instead of being retyped per screen. The F7 has no fallback network, so
+  bootstrapping one leaves a remembered second network untouched.
+
 ### Fixed
 
 - **Scanning for a screen to flash no longer kicks it into a refresh.** The scan

--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,3 +1,12 @@
+hokku-server (4.0.1~dev.13-1) unstable; urgency=medium
+
+  * feat(webserver): remember the flash Wi-Fi credentials for the Bigme F7
+    bootstrap form too. The persist step is now shared by both flash routes,
+    so the SSID/password pre-fill from the last flash of either kind; the F7
+    has no fallback network, so it leaves a remembered second one untouched.
+
+ -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Tue, 28 Jul 2026 22:39:55 -0500
+
 hokku-server (4.0.1~dev.12-1) unstable; urgency=medium
 
   * docs(bigme_f7): record two measured hardware findings — the power button

--- a/python/hokku/webserver/flask_app.py
+++ b/python/hokku/webserver/flask_app.py
@@ -1241,6 +1241,30 @@ def create_app(
             {"address": ip, "via": "ip", "port": port, "url": f"http://{ip}:{port}/hokku/screen/"}
         )
 
+    def _remember_flash_wifi(ssid1: str, pass1: str, ssid2: str | None, pass2: str | None) -> None:
+        """Persist the Wi-Fi credentials a flash just used so the form pre-fills.
+
+        Shared by every flash route — the same network provisions every screen,
+        whatever the model. ``ssid2``/``pass2`` are ``None`` for models without a
+        fallback network (the F7): those keep whatever was remembered before
+        instead of being cleared by a flash that never asked for them."""
+        if not config_path:
+            return
+        cfg = state.config
+        fields = {"flash_wifi_ssid": ssid1, "flash_wifi_pass": pass1}
+        if ssid2 is not None:
+            fields["flash_wifi_ssid2"] = ssid2
+            fields["flash_wifi_pass2"] = pass2 or ""
+        if all(getattr(cfg, k) == v for k, v in fields.items()):
+            return
+        try:
+            new_cfg = replace(cfg, **fields)
+            new_cfg.save(config_path)
+            with state._lock:
+                state.config = new_cfg
+        except Exception as e:
+            logger.warning("Could not persist WiFi credentials to config: %s", e)
+
     @app.route("/hokku/api/flash/start", methods=["POST"])
     def api_flash_start():
         """Begin flashing firmware + NVS config to a connected screen.
@@ -1315,29 +1339,9 @@ def create_app(
             return jsonify({"error": "a flash is already in progress"}), 409
 
         # Persist WiFi credentials so the form pre-fills next time.
-        wifi_pass1 = body.get("wifi_pass1") or ""
-        wifi_pass2 = body.get("wifi_pass2") or ""
-        if config_path:
-            cfg = state.config
-            if (
-                wifi_ssid1 != cfg.flash_wifi_ssid
-                or wifi_pass1 != cfg.flash_wifi_pass
-                or ssid2 != cfg.flash_wifi_ssid2
-                or wifi_pass2 != cfg.flash_wifi_pass2
-            ):
-                try:
-                    new_cfg = replace(
-                        cfg,
-                        flash_wifi_ssid=wifi_ssid1,
-                        flash_wifi_pass=wifi_pass1,
-                        flash_wifi_ssid2=ssid2,
-                        flash_wifi_pass2=wifi_pass2,
-                    )
-                    new_cfg.save(config_path)
-                    with state._lock:
-                        state.config = new_cfg
-                except Exception as e:
-                    logger.warning("Could not persist WiFi credentials to config: %s", e)
+        _remember_flash_wifi(
+            wifi_ssid1, body.get("wifi_pass1") or "", ssid2, body.get("wifi_pass2") or ""
+        )
 
         return jsonify({"job_id": job_id})
 
@@ -1383,6 +1387,12 @@ def create_app(
         if job_id is None:
             logger.warning("F7 bootstrap rejected: a flash is already in progress")
             return jsonify({"error": "a flash is already in progress"}), 409
+
+        # Persist WiFi credentials so the form pre-fills next time. The F7 has no
+        # fallback network, so the remembered second network is left alone.
+        if ssid:
+            _remember_flash_wifi(ssid, psk, None, None)
+
         return jsonify({"job_id": job_id})
 
     @app.route("/hokku/api/flash/cancel", methods=["POST"])

--- a/python/hokku/webserver/templates/index.html
+++ b/python/hokku/webserver/templates/index.html
@@ -3627,6 +3627,13 @@ async function loadConfig() {
       const body2 = document.getElementById('flash-second-body');
       if (body2) body2.hidden = false;
     }
+    // Same credentials for the F7 form — but its console can't take spaces, so
+    // only pre-fill values it could actually accept.
+    const f7s = document.getElementById('flash-f7-ssid');
+    const f7p = document.getElementById('flash-f7-pass');
+    const noSpace = v => v && !/\s/.test(v);
+    if (f7s && !f7s.value && noSpace(cfg.flash_wifi_ssid)) f7s.value = cfg.flash_wifi_ssid;
+    if (f7p && !f7p.value && noSpace(cfg.flash_wifi_pass)) f7p.value = cfg.flash_wifi_pass;
 
     currentConfig = cfg;
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hokku-server"
-version = "4.0.1.dev12"
+version = "4.0.1.dev13"
 description = "Spectra 6 e-ink image server for Hokku EL133UF1 display"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/tests/test_flash_common.py
+++ b/python/tests/test_flash_common.py
@@ -369,6 +369,37 @@ def test_flash_start_dispatches_selected_model_end_to_end(app_config, tmp_path, 
     assert captured["port"] == "COM9"
 
 
+def test_flash_start_remembers_wifi_credentials(app_config, tmp_path, monkeypatch):
+    """Flashing persists the Wi-Fi credentials to config so the form pre-fills
+    next time — the same network provisions every screen."""
+    fw = tmp_path / "hokku-huessen_epf1301-1.2.9.bin"
+    fw.write_bytes(b"\x00" * (APP_OFFSET + 256))
+    monkeypatch.setattr(huessen_epf1301, "merged_firmware_file", lambda *a, **k: fw)
+    monkeypatch.setattr(huessen_epf1301, "nvs_tool_available", lambda: True)
+    state = _bare_state(app_config)
+    monkeypatch.setattr(state.flash_jobs, "start", lambda *a, **k: 7)
+    client = _client(state, tmp_path)
+
+    r = client.post(
+        "/hokku/api/flash/start",
+        json={
+            "port": "COM9",
+            "wifi_ssid1": "Net",
+            "wifi_pass1": "secret",
+            "wifi_ssid2": "Net2",
+            "wifi_pass2": "secret2",
+            "image_url": "http://x/hokku/screen/",
+        },
+    )
+    assert r.status_code == 200
+    assert state.config.flash_wifi_ssid == "Net"
+    assert state.config.flash_wifi_pass == "secret"  # noqa: S105
+    assert state.config.flash_wifi_ssid2 == "Net2"
+    assert state.config.flash_wifi_pass2 == "secret2"
+    saved = json.loads((tmp_path / "cfg.json").read_text())
+    assert saved["flash_wifi_ssid"] == "Net"
+
+
 def _flash_ready_client(app_config, tmp_path, monkeypatch):
     """A client where huessen firmware + NVS tool are present, so /flash/start
     reaches field validation instead of short-circuiting on 503."""

--- a/python/tests/test_flash_f7.py
+++ b/python/tests/test_flash_f7.py
@@ -5,6 +5,7 @@ routes. Hardware-free — the BROM catch + slot-0 write are stubbed."""
 from __future__ import annotations
 
 import time
+from dataclasses import replace
 from pathlib import Path
 
 from hokku.screens import huessen_epf1301
@@ -508,6 +509,56 @@ def test_route_start_f7_no_provision_when_blank(app_config, tmp_path, monkeypatc
     assert r.status_code == 200
     _wait_state(state.flash_jobs, "done")
     assert captured["provision"] is None
+
+
+def _f7_ready(tmp_path, monkeypatch):
+    img = tmp_path / "xr_system.img"
+    img.write_bytes(b"AWIH" + b"\x00" * 32)
+    monkeypatch.setattr(bigme_bootstrap, "tooling_available", lambda: True)
+    monkeypatch.setattr("hokku.webserver.flask_app.bigme_firmware.firmware_image_file", lambda: img)
+    monkeypatch.setattr(
+        flashing.f7_bootstrap,
+        "bootstrap_device",
+        lambda port, image_path, on_line, should_cancel, provision=None, **kw: {"ok": True},
+    )
+
+
+def test_route_start_f7_remembers_wifi_credentials(app_config, tmp_path, monkeypatch):
+    """A bootstrap persists its Wi-Fi credentials like the ESP32 flash does, so
+    the form pre-fills next time. The F7 has no fallback network, so a previously
+    remembered second network must survive untouched."""
+    _f7_ready(tmp_path, monkeypatch)
+    cfg = replace(app_config, flash_wifi_ssid2="Old2", flash_wifi_pass2="oldpw2")
+    state = _bare_state(cfg)
+    client = _client(state, tmp_path)
+
+    r = client.post(
+        "/hokku/api/flash/start_f7",
+        json={"port": "COM7", "wifi_ssid1": "Net", "wifi_pass1": "secret"},
+    )
+    assert r.status_code == 200
+    _wait_state(state.flash_jobs, "done")
+    assert state.config.flash_wifi_ssid == "Net"
+    assert state.config.flash_wifi_pass == "secret"  # noqa: S105
+    assert state.config.flash_wifi_ssid2 == "Old2"  # not clobbered by a model without one
+    assert state.config.flash_wifi_pass2 == "oldpw2"
+
+
+def test_route_start_f7_without_wifi_keeps_remembered_credentials(
+    app_config, tmp_path, monkeypatch
+):
+    """Bootstrapping with the Wi-Fi fields blank (provision skipped) must not wipe
+    the remembered credentials."""
+    _f7_ready(tmp_path, monkeypatch)
+    cfg = replace(app_config, flash_wifi_ssid="Net", flash_wifi_pass="secret")
+    state = _bare_state(cfg)
+    client = _client(state, tmp_path)
+
+    r = client.post("/hokku/api/flash/start_f7", json={"port": "COM7"})
+    assert r.status_code == 200
+    _wait_state(state.flash_jobs, "done")
+    assert state.config.flash_wifi_ssid == "Net"
+    assert state.config.flash_wifi_pass == "secret"  # noqa: S105
 
 
 def test_route_start_f7_rejects_spaces(app_config, tmp_path, monkeypatch):


### PR DESCRIPTION
The ESP32 *Flash a screen* form already pre-filled its Wi-Fi fields from the last flash; the Bigme F7 bootstrap form did not — so every F7 meant retyping an SSID and password that are the same for every screen on the network.

## What changed

- The credential-persist step that `/flash/start` ran inline is now a single `_remember_flash_wifi()` helper, called by both flash routes.
- `/flash/start_f7` persists what it provisioned. The F7 firmware has no fallback network, so it passes `None` for the second SSID/password and leaves a remembered fallback untouched rather than clearing it. A bootstrap with the Wi-Fi fields blank (flash only, no provisioning) persists nothing.
- The F7 form pre-fills from the same remembered credentials as the ESP32 form, so either kind of flash fills in the other next time. The F7 console tokenizer can't take whitespace, so the F7 fields only pre-fill when the remembered values are space-free — otherwise the form would fill in a value it then rejects on submit.

## Tests

Three new: the F7 route persists and leaves the fallback alone, a blank F7 bootstrap keeps what was remembered, and the ESP32 route still persists all four fields (a regression guard on the extracted helper). Full suite 804 passed / 5 skipped; ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)