### PR TITLE
Add photo collections and per-frame collection selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ All three use **E Ink Spectra 6**, so one photo library feeds every frame — an
 - **Local-only** — your photos never leave your network. No cloud, no third-party servers, no telemetry. The web app itself makes no external requests — fonts and assets are self-hosted, so nothing is phoned home just by opening a browser tab. Your hardware and open source software means you're in full control.
 - **Drag-and-drop upload** — single files or dozens at a time, straight into the web app, with a live progress list. Works on phones too.
 - **Browse in a grid** — preview exactly what the frame will show before it shows it, original and converted version side by side. Delete anything you don't want with one click.
+- **Photo collections** — group photos into named collections such as Family, Travel or Favorites without copying files, then choose a collection independently for each frame.
 - **Click any photo** — see how it was processed and compare the original against what's going to the frame at full size.
 - **All the formats you actually have** — JPEG, PNG, HEIC/HEIF, AVIF, WebP, GIF, TIFF, BMP, JPEG XL. Anything from 90s scanned prints to modern iPhone, Android, and JPEG XL. Phone photos auto-rotate.
 - **Landscape or portrait** — flip a switch and everything re-converts to match how the frame is mounted.
@@ -38,6 +39,7 @@ All three use **E Ink Spectra 6**, so one photo library feeds every frame — an
 - **Flash frames from the web app** — if you're running the server on the same machine you use for setup (the appliance scenario), connect a frame via USB and use "Flash a screen" in the web app directly, without running any setup wizard separately. On the Pi Zero 2 W appliance the single USB port is dual-role, so **boot the appliance with nothing on the data port, then hot-plug the frame** (through a micro-USB→USB-A OTG adapter, with the Pi powered from its PWR port) — a frame attached at boot stops the appliance from starting. See [the appliance guide](docs/appliance.md#flashing-a-frame-from-the-appliance).
 - **Multiple frames, one server** — each frame gets a name and shows up in a dashboard with battery level, WiFi signal, and when it'll next update. Mix models, sizes and orientations against one library: a 13.3" frame in the hall and a 7.3" on a shelf, each served images converted for its own panel.
 - **Per-frame settings** — orientation, crop behaviour and firmware updates are set per screen, not globally.
+- **Per-frame collections** — each frame can rotate through its own collection while All Photos preserves the default behavior for existing installations.
 - **Knows which firmware each frame runs** — the dashboard shows every frame's firmware version and flags the ones that are behind.
 - **Fair rotation** — every photo gets its turn. Newly uploaded photos go to the front of the queue; after that, whichever image has been shown least goes next.
 - **Battery lasts months** — the frame uses almost no power between refreshes. The web app shows a battery level for each frame and flags it red when it's getting low.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -53,6 +53,14 @@ Pictures using something other than the plain default show a small badge on thei
 
 **Queue control** — each thumbnail has a "Show next" button that immediately queues that photo to be shown on the frame at its next refresh. Use this when you want a specific photo on the wall without waiting for normal rotation. The server uses a fair rotation algorithm — each image gets equal screen time over the long run, with newly uploaded photos jumping to the front of the queue. The "Show next" button effectively sets an image's priority to maximum.
 
+**Collections** — use the collection filter above the grid to view *All Photos*
+or a named collection. Collections are metadata, so adding a photo to several
+collections never copies or moves the original. Open **Manage collections** to
+create, rename, or delete a collection; deleting one leaves its photos in the
+library. Select one or more thumbnails to add them to, or remove them from, a
+collection. Existing installations automatically start with *All Photos*, and
+that remains the default behavior.
+
 **Deleting** — the trash button on each thumbnail deletes the original and all cached conversions. The frame will never show that image again.
 
 ### 1.2 Screens
@@ -74,6 +82,14 @@ The Screens tab shows every frame that has ever connected to this server. Each e
 **Multiple frames** — every frame that connects is tracked independently. You can run as many frames as you like from a single server, and they don't have to be the same model: a 13.3" frame and a 7.3" Bigme F7 can run side by side off the same library, each served images converted for its own panel. Give each one a distinct name so you can tell them apart in the dashboard. All frames share the same refresh schedule and image pool.
 
 **Per-screen orientation** — each frame carries its own orientation, set in the Screens tab. A frame mounted in portrait can show portrait-rendered images while another in landscape shows landscape ones, both served from the same library. A brand-new frame defaults to landscape until you change it.
+
+**Active collection** — each frame can use a different collection. Choose it
+from the collection selector in the Screens table or in that frame's Config
+dialog. The choice is saved immediately and takes effect on the frame's next
+scheduled refresh; it does not wake a sleeping frame. Press the physical frame
+button if you want it to refresh immediately. If the selected collection has
+no eligible photos, Hokku keeps the current displayed image and shows a warning
+until the collection has a ready photo.
 
 **Firmware version** — each frame reports the firmware it's running, shown in the
 dashboard. If the server is carrying a newer build for that model, the frame is
@@ -196,4 +212,5 @@ The following docs cover specific subsystems in detail:
 - **[appliance.md](appliance.md)** — the SD-card image: write it, join its WiFi, fill in a form.
 - **[install.md](install.md)** — full installation reference: manual installation on any platform, configuration file format and loading order.
 - **[dithering.md](dithering.md)** — how images are converted to the six-colour palette, why the defaults are what they are, what each setting does, and how to tune for specific types of photo.
+- **Collections API** — collection CRUD uses `/hokku/api/collections`; membership uses `/hokku/api/collections/<id>/images`; per-frame selection uses `/hokku/api/screens/<screen>/collection`. These endpoints are local JSON APIs intended for the web app and future automation clients. `All Photos` has the stable ID `all` and cannot be renamed or deleted.
 - **Per-screen documentation** — [Hokku / Huessen 13.3"](screens/huessen_epf1301/README.md) · [Bigme F7](screens/bigme_f7/README.md) · [Seeed reTerminal E1004](screens/seeedstudio_e1004/README.md), each covering that model's hardware, firmware and quirks.

--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,3 +1,9 @@
+hokku-server (4.0.1~dev.17-1) unstable; urgency=medium
+
+  * Add metadata-backed photo collections and per-frame collection selection.
+
+ -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Sat, 05 Sep 2026 11:52:21 -0700
+
 hokku-server (4.0.1~dev.15-1) unstable; urgency=medium
 
   * The preset dropdown now follows the catalog's own order (shipped defaults
@@ -350,4 +356,3 @@ hokku-server (4.0.1~dev.21-1) unstable; urgency=medium
     Pi's RLIMIT_NPROC + thrashed RAM — a cold-cache re-JIT boot never settled.
 
  -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Sat, 25 Jul 2026 05:38:20 +0000
-

--- a/python/debian/changelog
+++ b/python/debian/changelog
@@ -1,3 +1,9 @@
+hokku-server (4.0.1~dev.20-1) unstable; urgency=medium
+
+  * Persist collection context and show the active serving collection in the UI.
+
+ -- Dennis Fleurbaaij <mail@dennisfleurbaaij.com>  Sat, 05 Sep 2026 13:55:00 -0700
+
 hokku-server (4.0.1~dev.17-1) unstable; urgency=medium
 
   * Add metadata-backed photo collections and per-frame collection selection.

--- a/python/hokku/webserver/app_state.py
+++ b/python/hokku/webserver/app_state.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 from hokku.webserver import image_renderer
 from hokku.webserver.app_config import AppConfig
+from hokku.webserver.collection_store import CollectionStore
 from hokku.webserver.flashing import FlashJobManager
 from hokku.webserver.image_classifier import ImageClassifier
 from hokku.webserver.image_manager_abstract import AbstractImageManager
@@ -82,6 +83,9 @@ class AppState:
         self.classifier = classifier
         self.manager = manager
         self.scheduler = scheduler
+        # The scheduler owns the store so collection membership and rotation
+        # always read the same metadata snapshot. Expose it here for routes.
+        self.collections = scheduler.collection_store
         self.watcher = watcher
         self._zc = zc  # live Zeroconf instance (None if mDNS disabled)
         # Screen-flashing job manager. Independent of config, so it is created
@@ -116,7 +120,8 @@ class AppState:
         # may take a moment; we don't want to block route handlers for that.
         new_classifier = ImageClassifier(new_config)
         new_manager = build_manager(new_config, new_classifier)
-        new_scheduler = ServeScheduler(new_manager)
+        new_collections = CollectionStore(new_config.cache_dir)
+        new_scheduler = ServeScheduler(new_manager, new_collections)
 
         with self._lock:
             self.config = new_config
@@ -124,6 +129,7 @@ class AppState:
             old_manager = self.manager
             self.manager = new_manager
             self.scheduler = new_scheduler
+            self.collections = new_collections
 
         # Retire, don't shut down: new_manager has already read the image DB, so
         # a parting flush from the old one would revert it. retire() stops the

--- a/python/hokku/webserver/collection_store.py
+++ b/python/hokku/webserver/collection_store.py
@@ -1,10 +1,9 @@
 """Persistent photo collection metadata.
 
-Collections are deliberately kept separate from the image cache.  A collection
+Collections are deliberately kept separate from the image cache. A collection
 contains image *names*, not copies of image files, so membership changes do not
-touch conversion artifacts or serve statistics.  ``all`` is a protected virtual
-collection: it represents every image in the library and is the backward-
-compatible default for existing installations.
+touch conversion artifacts or serve statistics. ``all`` is a protected virtual
+view of every image in the library, not a persisted collection or membership.
 """
 
 from __future__ import annotations
@@ -23,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 _DB_FILENAME = "collections.json"
-_DB_VERSION = 1
+_DB_VERSION = 2
 ALL_COLLECTION_ID = "all"
 ALL_COLLECTION_NAME = "All Photos"
 
@@ -33,7 +32,7 @@ class CollectionNotFoundError(KeyError):
 
 
 class CollectionImmutableError(ValueError):
-    """Raised when a caller tries to mutate the protected All Photos collection."""
+    """Raised when a caller tries to mutate the virtual All Photos view."""
 
 
 @dataclass(frozen=True)
@@ -78,38 +77,20 @@ class CollectionStore:
         self._members: dict[str, set[str]] = {}
         self._load()
 
-        # Creating the protected collection is the complete migration for an
-        # existing installation. Existing image files remain untouched and are
-        # included automatically by the virtual All Photos semantics.
-        with self._lock:
-            if ALL_COLLECTION_ID not in self._collections:
-                now = time.time()
-                self._collections[ALL_COLLECTION_ID] = Collection(
-                    id=ALL_COLLECTION_ID,
-                    name=ALL_COLLECTION_NAME,
-                    description="Every image in the library.",
-                    created_at=now,
-                    updated_at=now,
-                )
-                self._save_locked()
-
     @property
     def path(self) -> Path:
         return self._path
 
-    def list(self) -> list[Collection]:
+    def list(self, *, include_all: bool = False) -> list[Collection]:
         with self._lock:
-            return sorted(
-                self._collections.values(),
-                key=lambda c: (c.id != ALL_COLLECTION_ID, c.name.casefold()),
-            )
+            collections = sorted(self._collections.values(), key=lambda c: c.name.casefold())
+            if include_all:
+                return [self._all_view(), *collections]
+            return collections
 
     def get(self, collection_id: str) -> Collection:
         with self._lock:
-            try:
-                return self._collections[collection_id]
-            except KeyError as e:
-                raise CollectionNotFoundError(collection_id) from e
+            return self._require(collection_id)
 
     def contains(self, collection_id: str, image_name: str) -> bool:
         with self._lock:
@@ -122,12 +103,16 @@ class CollectionStore:
         """Return explicit membership names; All Photos is resolved by its caller."""
         with self._lock:
             self._require(collection_id)
+            if collection_id == ALL_COLLECTION_ID:
+                return set()
             return set(self._members.get(collection_id, set()))
 
     def create(self, name: str, description: str = "") -> Collection:
         clean_name = self._validate_name(name)
         clean_description = self._validate_description(description)
         with self._lock:
+            if clean_name.casefold() == ALL_COLLECTION_NAME.casefold():
+                raise ValueError("All Photos is the unfiltered view, not a collection")
             if any(c.name.casefold() == clean_name.casefold() for c in self._collections.values()):
                 raise ValueError(f"A collection named {clean_name!r} already exists")
             now = time.time()
@@ -208,6 +193,41 @@ class CollectionStore:
                 self._save_locked()
             return before - len(members)
 
+    def image_collections(self, image_name: str) -> set[str]:
+        """Return the explicit collection IDs containing ``image_name``."""
+        with self._lock:
+            return {
+                collection_id
+                for collection_id, members in self._members.items()
+                if collection_id in self._collections and image_name in members
+            }
+
+    def set_image_collections(
+        self, image_name: str, collection_ids: list[str] | set[str]
+    ) -> set[str]:
+        """Replace an image's explicit memberships and return the resulting IDs."""
+        if not isinstance(collection_ids, (list, set)):
+            raise ValueError("collection_ids must be a list of collection IDs")
+        ids = set()
+        with self._lock:
+            for collection_id in collection_ids:
+                if not isinstance(collection_id, str) or not collection_id:
+                    raise ValueError("collection IDs must be non-empty strings")
+                self._require_mutable(collection_id)
+                ids.add(collection_id)
+            current = self.image_collections(image_name)
+            changed = current.symmetric_difference(ids)
+            for collection_id in changed:
+                members = self._members.setdefault(collection_id, set())
+                if collection_id in ids:
+                    members.add(image_name)
+                else:
+                    members.discard(image_name)
+                self._touch_locked(collection_id)
+            if changed:
+                self._save_locked()
+            return ids
+
     def remove_image(self, image_name: str) -> None:
         """Remove a deleted library image from every explicit collection."""
         with self._lock:
@@ -221,6 +241,8 @@ class CollectionStore:
                 self._save_locked()
 
     def _require(self, collection_id: str) -> Collection:
+        if collection_id == ALL_COLLECTION_ID:
+            return self._all_view()
         try:
             return self._collections[collection_id]
         except KeyError as e:
@@ -276,13 +298,15 @@ class CollectionStore:
         if not isinstance(data, dict):
             logger.warning("Invalid %s root (starting with All Photos)", _DB_FILENAME)
             return
-        if data.get("version") != _DB_VERSION:
+        version = data.get("version")
+        if version not in (1, _DB_VERSION):
             logger.warning(
-                "Unsupported %s version %r (starting with All Photos)",
+                "Unsupported %s version %r (starting with empty collections)",
                 _DB_FILENAME,
-                data.get("version"),
+                version,
             )
             return
+        needs_migration = version != _DB_VERSION
         raw_collections = data.get("collections", [])
         if not isinstance(raw_collections, list):
             logger.warning("Invalid collections in %s (starting with All Photos)", _DB_FILENAME)
@@ -294,19 +318,31 @@ class CollectionStore:
                 logger.warning("Skipping malformed collection: %s", e)
                 continue
             if collection.id == ALL_COLLECTION_ID:
-                collection = replace(
-                    collection,
-                    name=ALL_COLLECTION_NAME,
-                    description="Every image in the library.",
-                )
+                needs_migration = True
+                continue
             self._collections[collection.id] = collection
         raw_members = data.get("memberships", {})
         if isinstance(raw_members, dict):
-            self._members = {
-                collection_id: {name for name in names if isinstance(name, str)}
-                for collection_id, names in raw_members.items()
-                if isinstance(collection_id, str) and isinstance(names, list)
-            }
+            for collection_id, names in raw_members.items():
+                if not isinstance(collection_id, str) or not isinstance(names, list):
+                    needs_migration = True
+                    continue
+                if collection_id == ALL_COLLECTION_ID or collection_id not in self._collections:
+                    needs_migration = True
+                    continue
+                self._members[collection_id] = {name for name in names if isinstance(name, str)}
+        if needs_migration:
+            self._save_locked()
+
+    @staticmethod
+    def _all_view() -> Collection:
+        return Collection(
+            id=ALL_COLLECTION_ID,
+            name=ALL_COLLECTION_NAME,
+            description="Every image in the library.",
+            created_at=0.0,
+            updated_at=0.0,
+        )
 
     def _save_locked(self) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)

--- a/python/hokku/webserver/collection_store.py
+++ b/python/hokku/webserver/collection_store.py
@@ -1,0 +1,324 @@
+"""Persistent photo collection metadata.
+
+Collections are deliberately kept separate from the image cache.  A collection
+contains image *names*, not copies of image files, so membership changes do not
+touch conversion artifacts or serve statistics.  ``all`` is a protected virtual
+collection: it represents every image in the library and is the backward-
+compatible default for existing installations.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import uuid
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from hokku.webserver.filesystem import atomic_write_json
+
+logger = logging.getLogger(__name__)
+
+
+_DB_FILENAME = "collections.json"
+_DB_VERSION = 1
+ALL_COLLECTION_ID = "all"
+ALL_COLLECTION_NAME = "All Photos"
+
+
+class CollectionNotFoundError(KeyError):
+    """Raised when an API or scheduler references an unknown collection."""
+
+
+class CollectionImmutableError(ValueError):
+    """Raised when a caller tries to mutate the protected All Photos collection."""
+
+
+@dataclass(frozen=True)
+class Collection:
+    id: str
+    name: str
+    description: str
+    created_at: float
+    updated_at: float
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Collection:
+        collection_id = str(data["id"])
+        name = str(data["name"]).strip()
+        if not collection_id or not name:
+            raise ValueError("collection id and name are required")
+        return cls(
+            id=collection_id,
+            name=name,
+            description=str(data.get("description", "")),
+            created_at=float(data.get("created_at", time.time())),
+            updated_at=float(data.get("updated_at", time.time())),
+        )
+
+
+class CollectionStore:
+    """Thread-safe, atomic JSON metadata store for collections and membership."""
+
+    def __init__(self, cache_dir: str | Path) -> None:
+        self._path = Path(cache_dir) / _DB_FILENAME
+        self._lock = threading.RLock()
+        self._collections: dict[str, Collection] = {}
+        self._members: dict[str, set[str]] = {}
+        self._load()
+
+        # Creating the protected collection is the complete migration for an
+        # existing installation. Existing image files remain untouched and are
+        # included automatically by the virtual All Photos semantics.
+        with self._lock:
+            if ALL_COLLECTION_ID not in self._collections:
+                now = time.time()
+                self._collections[ALL_COLLECTION_ID] = Collection(
+                    id=ALL_COLLECTION_ID,
+                    name=ALL_COLLECTION_NAME,
+                    description="Every image in the library.",
+                    created_at=now,
+                    updated_at=now,
+                )
+                self._save_locked()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def list(self) -> list[Collection]:
+        with self._lock:
+            return sorted(
+                self._collections.values(),
+                key=lambda c: (c.id != ALL_COLLECTION_ID, c.name.casefold()),
+            )
+
+    def get(self, collection_id: str) -> Collection:
+        with self._lock:
+            try:
+                return self._collections[collection_id]
+            except KeyError as e:
+                raise CollectionNotFoundError(collection_id) from e
+
+    def contains(self, collection_id: str, image_name: str) -> bool:
+        with self._lock:
+            self._require(collection_id)
+            return collection_id == ALL_COLLECTION_ID or image_name in self._members.get(
+                collection_id, set()
+            )
+
+    def image_names(self, collection_id: str) -> set[str]:
+        """Return explicit membership names; All Photos is resolved by its caller."""
+        with self._lock:
+            self._require(collection_id)
+            return set(self._members.get(collection_id, set()))
+
+    def create(self, name: str, description: str = "") -> Collection:
+        clean_name = self._validate_name(name)
+        clean_description = self._validate_description(description)
+        with self._lock:
+            if any(c.name.casefold() == clean_name.casefold() for c in self._collections.values()):
+                raise ValueError(f"A collection named {clean_name!r} already exists")
+            now = time.time()
+            collection = Collection(
+                id=uuid.uuid4().hex,
+                name=clean_name,
+                description=clean_description,
+                created_at=now,
+                updated_at=now,
+            )
+            self._collections[collection.id] = collection
+            self._members[collection.id] = set()
+            self._save_locked()
+            return collection
+
+    def update(
+        self,
+        collection_id: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> Collection:
+        with self._lock:
+            current = self._require(collection_id)
+            if collection_id == ALL_COLLECTION_ID:
+                raise CollectionImmutableError("All Photos cannot be renamed or edited")
+            clean_name = current.name if name is None else self._validate_name(name)
+            clean_description = (
+                current.description
+                if description is None
+                else self._validate_description(description)
+            )
+            if any(
+                c.id != collection_id and c.name.casefold() == clean_name.casefold()
+                for c in self._collections.values()
+            ):
+                raise ValueError(f"A collection named {clean_name!r} already exists")
+            updated = replace(
+                current,
+                name=clean_name,
+                description=clean_description,
+                updated_at=time.time(),
+            )
+            self._collections[collection_id] = updated
+            self._save_locked()
+            return updated
+
+    def delete(self, collection_id: str) -> None:
+        with self._lock:
+            self._require(collection_id)
+            if collection_id == ALL_COLLECTION_ID:
+                raise CollectionImmutableError("All Photos cannot be deleted")
+            del self._collections[collection_id]
+            self._members.pop(collection_id, None)
+            self._save_locked()
+
+    def add_images(self, collection_id: str, image_names: list[str] | set[str]) -> int:
+        names = self._validate_image_names(image_names)
+        with self._lock:
+            self._require_mutable(collection_id)
+            members = self._members.setdefault(collection_id, set())
+            before = len(members)
+            members.update(names)
+            if len(members) != before:
+                self._touch_locked(collection_id)
+                self._save_locked()
+            return len(members) - before
+
+    def remove_images(self, collection_id: str, image_names: list[str] | set[str]) -> int:
+        names = self._validate_image_names(image_names)
+        with self._lock:
+            self._require_mutable(collection_id)
+            members = self._members.setdefault(collection_id, set())
+            before = len(members)
+            members.difference_update(names)
+            if len(members) != before:
+                self._touch_locked(collection_id)
+                self._save_locked()
+            return before - len(members)
+
+    def remove_image(self, image_name: str) -> None:
+        """Remove a deleted library image from every explicit collection."""
+        with self._lock:
+            changed = False
+            for collection_id, members in self._members.items():
+                if image_name in members:
+                    members.remove(image_name)
+                    self._touch_locked(collection_id)
+                    changed = True
+            if changed:
+                self._save_locked()
+
+    def _require(self, collection_id: str) -> Collection:
+        try:
+            return self._collections[collection_id]
+        except KeyError as e:
+            raise CollectionNotFoundError(collection_id) from e
+
+    def _require_mutable(self, collection_id: str) -> Collection:
+        collection = self._require(collection_id)
+        if collection_id == ALL_COLLECTION_ID:
+            raise CollectionImmutableError("All Photos membership is automatic")
+        return collection
+
+    def _touch_locked(self, collection_id: str) -> None:
+        current = self._collections[collection_id]
+        self._collections[collection_id] = replace(current, updated_at=time.time())
+
+    @staticmethod
+    def _validate_name(name: str) -> str:
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("collection name must not be empty")
+        clean = name.strip()
+        if len(clean) > 120:
+            raise ValueError("collection name must be 120 characters or fewer")
+        return clean
+
+    @staticmethod
+    def _validate_description(description: str) -> str:
+        if not isinstance(description, str):
+            raise ValueError("collection description must be a string")
+        if len(description) > 500:
+            raise ValueError("collection description must be 500 characters or fewer")
+        return description.strip()
+
+    @staticmethod
+    def _validate_image_names(image_names: list[str] | set[str]) -> set[str]:
+        if not isinstance(image_names, (list, set)):
+            raise ValueError("images must be a list of image names")
+        names = set()
+        for name in image_names:
+            if not isinstance(name, str) or not name or "/" in name or "\\" in name:
+                raise ValueError("image names must be non-empty filenames")
+            names.add(name)
+        return names
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            with open(self._path) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning("Failed to load %s: %s (starting with All Photos)", _DB_FILENAME, e)
+            return
+        if not isinstance(data, dict):
+            logger.warning("Invalid %s root (starting with All Photos)", _DB_FILENAME)
+            return
+        if data.get("version") != _DB_VERSION:
+            logger.warning(
+                "Unsupported %s version %r (starting with All Photos)",
+                _DB_FILENAME,
+                data.get("version"),
+            )
+            return
+        raw_collections = data.get("collections", [])
+        if not isinstance(raw_collections, list):
+            logger.warning("Invalid collections in %s (starting with All Photos)", _DB_FILENAME)
+            raw_collections = []
+        for blob in raw_collections:
+            try:
+                collection = Collection.from_dict(blob)
+            except (KeyError, TypeError, ValueError) as e:
+                logger.warning("Skipping malformed collection: %s", e)
+                continue
+            if collection.id == ALL_COLLECTION_ID:
+                collection = replace(
+                    collection,
+                    name=ALL_COLLECTION_NAME,
+                    description="Every image in the library.",
+                )
+            self._collections[collection.id] = collection
+        raw_members = data.get("memberships", {})
+        if isinstance(raw_members, dict):
+            self._members = {
+                collection_id: {name for name in names if isinstance(name, str)}
+                for collection_id, names in raw_members.items()
+                if isinstance(collection_id, str) and isinstance(names, list)
+            }
+
+    def _save_locked(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_json(
+            self._path,
+            {
+                "version": _DB_VERSION,
+                "collections": [c.to_dict() for c in self.list()],
+                "memberships": {
+                    collection_id: sorted(names)
+                    for collection_id, names in self._members.items()
+                    if collection_id in self._collections
+                },
+            },
+        )

--- a/python/hokku/webserver/flask_app.py
+++ b/python/hokku/webserver/flask_app.py
@@ -652,7 +652,17 @@ def create_app(
         if not files:
             logger.info("Upload rejected: no files in request")
             return jsonify({"error": "No files in upload"}), 400
+        raw_collection_id = request.form.get("collection_id")
+        collection_id = (
+            raw_collection_id if raw_collection_id not in (None, "", ALL_COLLECTION_ID) else None
+        )
+        if collection_id is not None:
+            try:
+                state.collections.get(collection_id)
+            except CollectionNotFoundError:
+                return jsonify({"error": f"collection {collection_id!r} not found"}), 404
         saved, skipped = [], []
+        collection_added = []
         for f in files:
             if not f or not f.filename:
                 continue
@@ -699,12 +709,33 @@ def create_app(
             try:
                 manager.add(name, data)
                 saved.append(name)
+                if collection_id is not None:
+                    state.collections.add_images(collection_id, [name])
+                    collection_added.append(name)
             except FileExistsError:
-                skipped.append({"name": name, "reason": "already exists; remove to replace"})
+                if collection_id is not None:
+                    state.collections.add_images(collection_id, [name])
+                    collection_added.append(name)
+                    skipped.append(
+                        {
+                            "name": name,
+                            "reason": "already exists; added to collection",
+                            "collection_added": True,
+                        }
+                    )
+                else:
+                    skipped.append({"name": name, "reason": "already exists; remove to replace"})
             except (OSError, ValueError) as e:
                 logger.error("Error adding %r: %s: %s", name, type(e).__name__, e)
                 skipped.append({"name": name, "reason": str(e)})
-        return jsonify({"saved": saved, "skipped": skipped})
+        return jsonify(
+            {
+                "saved": saved,
+                "skipped": skipped,
+                "collection_id": collection_id,
+                "collection_added": collection_added,
+            }
+        )
 
     @app.route("/hokku/api/image/<path:name>", methods=["DELETE"])
     def api_delete(name: str):
@@ -719,11 +750,45 @@ def create_app(
         state.collections.remove_image(name)
         return jsonify({"ok": True})
 
+    @app.route("/hokku/api/image/<path:name>/collections", methods=["GET", "PATCH"])
+    def api_image_collections(name: str):
+        known_names = {record.name for record in state.manager.list()}
+        if name not in known_names:
+            return jsonify({"error": f"image {name!r} not found"}), 404
+        if request.method == "GET":
+            return jsonify(
+                {"image": name, "collection_ids": sorted(state.collections.image_collections(name))}
+            )
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict) or set(body) != {"collection_ids"}:
+            return jsonify({"error": "collection_ids is required"}), 400
+        collection_ids = body["collection_ids"]
+        if not isinstance(collection_ids, list) or not all(
+            isinstance(collection_id, str) for collection_id in collection_ids
+        ):
+            return jsonify({"error": "collection_ids must be a list of strings"}), 400
+        before = state.collections.image_collections(name)
+        try:
+            after = state.collections.set_image_collections(name, collection_ids)
+        except CollectionNotFoundError as e:
+            return jsonify({"error": f"collection {e.args[0]!r} not found"}), 404
+        except (CollectionImmutableError, ValueError) as e:
+            return jsonify({"error": str(e)}), 409
+        for collection_id in before | after:
+            state.scheduler.invalidate_collection(collection_id)
+        return jsonify({"ok": True, "image": name, "collection_ids": sorted(after)})
+
     # ── API: collections ────────────────────────────────────────
 
     @app.route("/hokku/api/collections", methods=["GET"])
     def api_collections_list():
-        return jsonify({"collections": [_collection_payload(c) for c in state.collections.list()]})
+        return jsonify(
+            {
+                "collections": [
+                    _collection_payload(c) for c in state.collections.list(include_all=True)
+                ]
+            }
+        )
 
     @app.route("/hokku/api/collections", methods=["POST"])
     def api_collection_create():
@@ -839,6 +904,45 @@ def create_app(
                 "images": _collection_image_names(collection_id),
             }
         )
+
+    @app.route("/hokku/api/images/collections", methods=["POST", "DELETE"])
+    def api_bulk_image_collections():
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict) or set(body) != {"images", "collection_ids"}:
+            return jsonify({"error": "images and collection_ids are required"}), 400
+        image_names = body["images"]
+        collection_ids = body["collection_ids"]
+        if not isinstance(image_names, list) or not all(
+            isinstance(name, str) for name in image_names
+        ):
+            return jsonify({"error": "images must be a list of strings"}), 400
+        if not isinstance(collection_ids, list) or not all(
+            isinstance(collection_id, str) for collection_id in collection_ids
+        ):
+            return jsonify({"error": "collection_ids must be a list of strings"}), 400
+        known_names = {record.name for record in state.manager.list()}
+        unknown_images = sorted(set(image_names) - known_names)
+        if unknown_images:
+            return jsonify({"error": "unknown image(s)", "images": unknown_images}), 404
+        try:
+            for collection_id in collection_ids:
+                state.collections.get(collection_id)
+                if collection_id == ALL_COLLECTION_ID:
+                    raise CollectionImmutableError("All Photos membership is automatic")
+            changed = 0
+            for collection_id in collection_ids:
+                changed += (
+                    state.collections.add_images(collection_id, image_names)
+                    if request.method == "POST"
+                    else state.collections.remove_images(collection_id, image_names)
+                )
+        except CollectionNotFoundError as e:
+            return jsonify({"error": f"collection {e.args[0]!r} not found"}), 404
+        except (CollectionImmutableError, ValueError) as e:
+            return jsonify({"error": str(e)}), 409
+        for collection_id in collection_ids:
+            state.scheduler.invalidate_collection(collection_id)
+        return jsonify({"ok": True, "changed": changed})
 
     @app.route("/hokku/api/image/<path:name>/retry", methods=["POST"])
     def api_retry(name: str):
@@ -1417,7 +1521,10 @@ def create_app(
                 "failed_files": failed_files,
                 "serve_data": serve_data,
                 "screens": screens_payload,
-                "collections": [_collection_payload(c) for c in collections],
+                "collections": [
+                    _collection_payload(state.collections.get(ALL_COLLECTION_ID)),
+                    *[_collection_payload(c) for c in collections],
+                ],
                 "last_served": last[0] if last else None,
                 "converting": 1 if progress.current_name or progress.done < progress.total else 0,
                 "converting_name": progress.current_name,

--- a/python/hokku/webserver/flask_app.py
+++ b/python/hokku/webserver/flask_app.py
@@ -47,6 +47,11 @@ from hokku.screens.registry import DISPLAY_REGISTRY
 from hokku.webserver import firmware_github
 from hokku.webserver.app_config import AppConfig
 from hokku.webserver.app_state import AppState
+from hokku.webserver.collection_store import (
+    ALL_COLLECTION_ID,
+    CollectionImmutableError,
+    CollectionNotFoundError,
+)
 from hokku.webserver.dither_streaming_numba import NumbaStreamingDither
 from hokku.webserver.firmware_library import FirmwareStore
 from hokku.webserver.image_abc import transform_bboxes_to_canvas_norm
@@ -274,6 +279,23 @@ def create_app(
         ``state.config`` fresh each request."""
         return FirmwareStore(Path(state.config.firmware_dir))
 
+    def _collection_payload(collection) -> dict:
+        records = state.manager.list()
+        if collection.id == ALL_COLLECTION_ID:
+            image_count = len(records)
+        else:
+            members = state.collections.image_names(collection.id)
+            image_count = sum(1 for record in records if record.name in members)
+        payload = collection.to_dict()
+        payload["image_count"] = image_count
+        return payload
+
+    def _collection_image_names(collection_id: str) -> list[str]:
+        names = {record.name for record in state.manager.list()}
+        if collection_id == ALL_COLLECTION_ID:
+            return sorted(names, key=str.casefold)
+        return sorted(state.collections.image_names(collection_id) & names, key=str.casefold)
+
     # ── Firmware-facing ────────────────────────────────────────
 
     @app.route("/hokku/screen/", strict_slashes=False, methods=["GET", "POST"])
@@ -344,8 +366,42 @@ def create_app(
                 screen_log = raw.decode("utf-8", errors="replace")
 
         cfg = scheduler.get_screen_config(screen_name)
+        collection_id = cfg.active_collection_id or ALL_COLLECTION_ID
+        try:
+            state.collections.get(collection_id)
+        except CollectionNotFoundError:
+            logger.warning(
+                "Unknown active collection %r for %s; serving All Photos",
+                collection_id,
+                screen_name,
+            )
+            collection_id = ALL_COLLECTION_ID
         pick_orientation = cfg.orientation if cfg.filter_by_orientation else Orientation.NEUTRAL
-        chosen = scheduler.pick_next(orientation=pick_orientation)
+        collection_empty = (
+            collection_id != ALL_COLLECTION_ID
+            and not scheduler.collection_has_eligible(collection_id, pick_orientation)
+        )
+        preserve_current = False
+        if collection_empty:
+            # A collection change must never make a frame blank. Prefer the
+            # image the frame already has; if it is unavailable, fall back to
+            # All Photos so a stale/deleted image cannot strand the device.
+            current = scheduler.screen_last_served(screen_name)
+            if (
+                current
+                and manager.panel_bytes_for_model_orientation(
+                    current, screen_model, cfg.orientation
+                )
+                is not None
+            ):
+                chosen = current
+                preserve_current = True
+            else:
+                chosen = scheduler.pick_next(
+                    orientation=pick_orientation, collection_id=ALL_COLLECTION_ID
+                )
+        else:
+            chosen = scheduler.pick_next(orientation=pick_orientation, collection_id=collection_id)
         sleep_seconds = calculate_sleep_seconds(config) if chosen else _busy_retry_seconds(config)
 
         if chosen is None:
@@ -396,7 +452,8 @@ def create_app(
             resp.headers["X-Sleep-Seconds"] = str(sleep_seconds)
             return _add_cal_seed(resp)
 
-        scheduler.mark_served(chosen)
+        if not preserve_current:
+            scheduler.mark_served(chosen, collection_id=collection_id)
         scheduler.record_screen_call(
             screen_name,
             screen_ip,
@@ -659,7 +716,129 @@ def create_app(
         except OSError as e:
             logger.error("Delete failed for %r: %s", name, e)
             return jsonify({"error": str(e)}), 500
+        state.collections.remove_image(name)
         return jsonify({"ok": True})
+
+    # ── API: collections ────────────────────────────────────────
+
+    @app.route("/hokku/api/collections", methods=["GET"])
+    def api_collections_list():
+        return jsonify({"collections": [_collection_payload(c) for c in state.collections.list()]})
+
+    @app.route("/hokku/api/collections", methods=["POST"])
+    def api_collection_create():
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return jsonify({"error": "expected JSON object"}), 400
+        name = body.get("name")
+        if not isinstance(name, str):
+            return jsonify({"error": "name must be a string"}), 400
+        description = body.get("description", "")
+        if not isinstance(description, str):
+            return jsonify({"error": "description must be a string"}), 400
+        try:
+            collection = state.collections.create(name, description)
+        except (TypeError, ValueError) as e:
+            return jsonify({"error": str(e)}), 400
+        return jsonify(_collection_payload(collection)), 201
+
+    @app.route("/hokku/api/collections/<string:collection_id>", methods=["PATCH"])
+    def api_collection_update(collection_id: str):
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return jsonify({"error": "expected JSON object"}), 400
+        unknown = body.keys() - {"name", "description"}
+        if unknown:
+            return jsonify({"error": f"unknown field(s): {', '.join(sorted(unknown))}"}), 400
+        if "name" in body and not isinstance(body["name"], str):
+            return jsonify({"error": "name must be a string"}), 400
+        if "description" in body and not isinstance(body["description"], str):
+            return jsonify({"error": "description must be a string"}), 400
+        try:
+            collection = state.collections.update(
+                collection_id,
+                name=body.get("name"),
+                description=body.get("description"),
+            )
+        except CollectionNotFoundError:
+            return jsonify({"error": f"collection {collection_id!r} not found"}), 404
+        except (CollectionImmutableError, ValueError) as e:
+            return jsonify({"error": str(e)}), 409
+        return jsonify(_collection_payload(collection))
+
+    @app.route("/hokku/api/collections/<string:collection_id>", methods=["DELETE"])
+    def api_collection_delete(collection_id: str):
+        try:
+            state.collections.delete(collection_id)
+        except CollectionNotFoundError:
+            return jsonify({"error": f"collection {collection_id!r} not found"}), 404
+        except CollectionImmutableError as e:
+            return jsonify({"error": str(e)}), 409
+        state.scheduler.reset_active_collection(collection_id)
+        return jsonify({"ok": True})
+
+    @app.route(
+        "/hokku/api/collections/<string:collection_id>/images", methods=["GET", "POST", "DELETE"]
+    )
+    def api_collection_images(collection_id: str):
+        try:
+            state.collections.get(collection_id)
+        except CollectionNotFoundError:
+            return jsonify({"error": f"collection {collection_id!r} not found"}), 404
+
+        if request.method == "GET":
+            names = _collection_image_names(collection_id)
+            return jsonify({"collection_id": collection_id, "images": names, "count": len(names)})
+
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return jsonify({"error": "expected JSON object"}), 400
+        raw_names = body.get("images", body.get("names"))
+        if not isinstance(raw_names, list) or not all(isinstance(name, str) for name in raw_names):
+            return jsonify({"error": "images must be a list of image names"}), 400
+        known_names = {record.name for record in state.manager.list()}
+        unknown = sorted(set(raw_names) - known_names)
+        if unknown:
+            return jsonify({"error": "unknown image(s)", "images": unknown}), 404
+        try:
+            changed = (
+                state.collections.add_images(collection_id, raw_names)
+                if request.method == "POST"
+                else state.collections.remove_images(collection_id, raw_names)
+            )
+        except CollectionImmutableError as e:
+            return jsonify({"error": str(e)}), 409
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
+        state.scheduler.invalidate_collection(collection_id)
+        return jsonify(
+            {
+                "ok": True,
+                "changed": changed,
+                "collection_id": collection_id,
+                "images": _collection_image_names(collection_id),
+            }
+        )
+
+    @app.route(
+        "/hokku/api/collections/<string:collection_id>/images/<path:name>", methods=["DELETE"]
+    )
+    def api_collection_image_delete(collection_id: str, name: str):
+        try:
+            state.collections.get(collection_id)
+            state.collections.remove_images(collection_id, [name])
+        except CollectionNotFoundError:
+            return jsonify({"error": f"collection {collection_id!r} not found"}), 404
+        except (CollectionImmutableError, ValueError) as e:
+            return jsonify({"error": str(e)}), 409
+        state.scheduler.invalidate_collection(collection_id)
+        return jsonify(
+            {
+                "ok": True,
+                "collection_id": collection_id,
+                "images": _collection_image_names(collection_id),
+            }
+        )
 
     @app.route("/hokku/api/image/<path:name>/retry", methods=["POST"])
     def api_retry(name: str):
@@ -804,8 +983,10 @@ def create_app(
 
     @app.route("/hokku/api/screens/<string:name>/config", methods=["PATCH"])
     def api_screen_config(name: str):
-        """Patch per-screen config (orientation and/or orientation filter)."""
-        body = request.get_json(silent=True) or {}
+        """Patch per-screen config (orientation, filter, URL, or collection)."""
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return jsonify({"error": "expected JSON object"}), 400
         current = state.scheduler.get_screen_config(name)
         updates: dict = {}
 
@@ -831,10 +1012,82 @@ def create_app(
                 return jsonify({"error": "server_url_override must be a string"}), 400
             updates["server_url_override"] = val.strip()
 
+        if "active_collection_id" in body:
+            collection_id = body.get("active_collection_id")
+            if not isinstance(collection_id, str):
+                return jsonify({"error": "active_collection_id must be a string"}), 400
+            try:
+                state.collections.get(collection_id)
+            except CollectionNotFoundError:
+                return jsonify({"error": f"collection {collection_id!r} not found"}), 404
+            updates["active_collection_id"] = collection_id
+
         if updates:
             state.scheduler.set_screen_config(name, replace(current, **updates))
             state.manager.sync()
         return jsonify({"ok": True})
+
+    @app.route("/hokku/api/screens/<string:name>/collection", methods=["GET", "PATCH"])
+    def api_screen_collection(name: str):
+        """Read or set a frame's collection without involving its firmware.
+
+        ``refresh_now`` is accepted as an explicit false-only hint. Hokku's
+        battery-saving protocol has no server-side wake command; users can press
+        the frame button for an immediate refresh, while the new collection is
+        always used on the next scheduled poll.
+        """
+        config = state.scheduler.get_screen_config(name)
+        if request.method == "GET":
+            collection_id = config.active_collection_id or ALL_COLLECTION_ID
+            try:
+                collection = state.collections.get(collection_id)
+            except CollectionNotFoundError:
+                collection_id = ALL_COLLECTION_ID
+                collection = state.collections.get(collection_id)
+            return jsonify(
+                {
+                    "screen": name,
+                    "collection": _collection_payload(collection),
+                    "active_collection_id": collection_id,
+                }
+            )
+
+        body = request.get_json(silent=True)
+        if not isinstance(body, dict):
+            return jsonify({"error": "expected JSON object"}), 400
+        collection_id = body.get("collection_id", body.get("active_collection_id"))
+        if not isinstance(collection_id, str):
+            return jsonify({"error": "collection_id must be a string"}), 400
+        if "refresh_now" in body and body["refresh_now"] is not False:
+            return jsonify(
+                {
+                    "error": "Hokku cannot wake a sleeping frame over the existing protocol",
+                    "hint": "The frame button triggers an immediate refresh; the new collection is used on the next scheduled refresh.",
+                }
+            ), 409
+        try:
+            state.collections.get(collection_id)
+        except CollectionNotFoundError:
+            return jsonify({"error": f"collection {collection_id!r} not found"}), 404
+        state.scheduler.set_screen_config(name, replace(config, active_collection_id=collection_id))
+        state.scheduler.invalidate_collection(collection_id)
+        peek_orientation = (
+            config.orientation if config.filter_by_orientation else Orientation.NEUTRAL
+        )
+        return jsonify(
+            {
+                "ok": True,
+                "screen": name,
+                "collection": _collection_payload(state.collections.get(collection_id)),
+                "active_collection_id": collection_id,
+                "empty": (
+                    collection_id != ALL_COLLECTION_ID
+                    and not state.scheduler.collection_has_eligible(collection_id, peek_orientation)
+                ),
+                "refresh_requested": False,
+                "message": "Collection saved for the next scheduled refresh.",
+            }
+        )
 
     @app.route("/hokku/api/screens/<string:name>/update", methods=["POST"])
     def api_screen_update(name: str):
@@ -1018,6 +1271,7 @@ def create_app(
         _budget = compute_budget(state.config.memory_budget_mb)
 
         records = manager.list()
+        collections = state.collections.list()
         progress = manager.conversion_progress()
         last = scheduler.last_served()
         classifier = state.classifier
@@ -1051,6 +1305,11 @@ def create_app(
                 "has_image_config_override": r.image_config is not None,
                 "crop_to_fill_threshold": r.crop_to_fill_threshold,
                 "pipeline": _pipeline_label(r, obs),
+                "collection_ids": [
+                    collection.id
+                    for collection in collections
+                    if state.collections.contains(collection.id, r.name)
+                ],
             }
             upload_files.append(entry)
             if r.convert_status == ConvertStatus.FAILED:
@@ -1083,6 +1342,12 @@ def create_app(
                     t.last_seen_at + t.last_sleep_seconds
                 ).isoformat(timespec="seconds")
             scfg = scheduler.get_screen_config(sname)
+            active_collection_id = scfg.active_collection_id or ALL_COLLECTION_ID
+            try:
+                active_collection = state.collections.get(active_collection_id)
+            except CollectionNotFoundError:
+                active_collection_id = ALL_COLLECTION_ID
+                active_collection = state.collections.get(active_collection_id)
             peek_orientation = (
                 scfg.orientation if scfg.filter_by_orientation else Orientation.NEUTRAL
             )
@@ -1114,6 +1379,15 @@ def create_app(
                 "orientation": scfg.orientation,
                 "filter_by_orientation": scfg.filter_by_orientation,
                 "server_url_override": scfg.server_url_override,
+                "active_collection_id": active_collection_id,
+                "active_collection": _collection_payload(active_collection),
+                "active_collection_empty": (
+                    active_collection_id != ALL_COLLECTION_ID
+                    and not scheduler.collection_has_eligible(
+                        active_collection_id, peek_orientation
+                    )
+                ),
+                "next_image": scheduler.peek_next(peek_orientation, active_collection_id),
                 "last_log": t.last_log or None,
                 "last_log_at": (
                     datetime.fromtimestamp(t.last_log_at).isoformat(timespec="seconds")
@@ -1143,6 +1417,7 @@ def create_app(
                 "failed_files": failed_files,
                 "serve_data": serve_data,
                 "screens": screens_payload,
+                "collections": [_collection_payload(c) for c in collections],
                 "last_served": last[0] if last else None,
                 "converting": 1 if progress.current_name or progress.done < progress.total else 0,
                 "converting_name": progress.current_name,

--- a/python/hokku/webserver/screen_config.py
+++ b/python/hokku/webserver/screen_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from hokku.webserver.collection_store import ALL_COLLECTION_ID
 from hokku.webserver.orientation import Orientation
 
 
@@ -24,6 +25,7 @@ class ScreenConfig:
     orientation: Orientation = Orientation.LANDSCAPE
     filter_by_orientation: bool = False
     server_url_override: str = ""
+    active_collection_id: str = ALL_COLLECTION_ID
 
     def __post_init__(self) -> None:
         assert self.orientation in (Orientation.LANDSCAPE, Orientation.PORTRAIT), (
@@ -35,12 +37,19 @@ class ScreenConfig:
             "orientation": self.orientation,
             "filter_by_orientation": self.filter_by_orientation,
             "server_url_override": self.server_url_override,
+            "active_collection_id": self.active_collection_id,
         }
 
     @classmethod
     def from_dict(cls, d: dict) -> ScreenConfig:
+        raw_collection_id = d.get("active_collection_id", ALL_COLLECTION_ID)
         return cls(
             orientation=Orientation(d["orientation"]),
             filter_by_orientation=bool(d.get("filter_by_orientation", False)),
             server_url_override=str(d.get("server_url_override", "")),
+            active_collection_id=(
+                raw_collection_id
+                if isinstance(raw_collection_id, str) and raw_collection_id
+                else ALL_COLLECTION_ID
+            ),
         )

--- a/python/hokku/webserver/serve_scheduler.py
+++ b/python/hokku/webserver/serve_scheduler.py
@@ -5,6 +5,10 @@ One DB file (``serve_scheduler.json``) carries all of:
 - ``last_served``: which image was served last (used for time-shown attribution)
 - ``screens``: per-screen telemetry (request count, battery, frame state)
 - ``next_for``: pre-computed next image per orientation (LANDSCAPE, PORTRAIT, NEUTRAL)
+
+Collection membership is metadata-only. The existing global serve statistics are
+shared by every collection, while cached next-image pointers are maintained per
+collection so changing a frame's selection does not disturb fair rotation.
 """
 
 from __future__ import annotations
@@ -17,6 +21,11 @@ import time
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 
+from hokku.webserver.collection_store import (
+    ALL_COLLECTION_ID,
+    CollectionNotFoundError,
+    CollectionStore,
+)
 from hokku.webserver.filesystem import atomic_write_json
 from hokku.webserver.image_manager_abstract import AbstractImageManager
 from hokku.webserver.image_record import ConvertStatus, ImageRecord
@@ -129,8 +138,11 @@ class ScreenTelemetryEntry:
 class ServeScheduler:
     """Fair-rotation scheduler + screen telemetry collector."""
 
-    def __init__(self, manager: AbstractImageManager) -> None:
+    def __init__(
+        self, manager: AbstractImageManager, collection_store: CollectionStore | None = None
+    ) -> None:
         self._manager = manager
+        self._collections = collection_store or CollectionStore(manager.config.cache_dir)
         self._db_path = Path(manager.config.cache_dir) / _DB_FILENAME
         self._lock = threading.RLock()
         self._stats: dict[str, ServeStats] = {}  # keyed by IMAGE name (rotation)
@@ -154,6 +166,9 @@ class ServeScheduler:
         self._ota_attempts: dict[str, int] = {}
         self._last_served: tuple[str, float] | None = None
         self._next_for: dict[Orientation, str | None] = dict.fromkeys(Orientation, None)
+        self._next_for_by_collection: dict[str, dict[Orientation, str | None]] = {
+            ALL_COLLECTION_ID: self._next_for
+        }
         self._load()
         # Pre-determine the next image right now so the UI can show it
         # immediately without waiting for the first screen request.
@@ -162,11 +177,13 @@ class ServeScheduler:
             if ready:
                 ready_names = {r.name for r in ready}
                 self._reconcile(ready_names)
-                self._precompute_all_locked(ready)
+                self._precompute_all_locked(ready, ALL_COLLECTION_ID)
 
     # ── Rotation ─────────────────────────────────────────────────
 
-    def pick_next(self, orientation: Orientation) -> str | None:
+    def pick_next(
+        self, orientation: Orientation, collection_id: str = ALL_COLLECTION_ID
+    ) -> str | None:
         """Return the pre-determined next image for the given orientation filter.
 
         orientation=NEUTRAL means no filter — returns the global best next image.
@@ -176,24 +193,26 @@ class ServeScheduler:
         """
         with self._lock:
             ready = [r for r in self._manager.list() if r.convert_status == ConvertStatus.OK]
-            ready_names = {r.name for r in ready}
-            self._reconcile(ready_names)
+            self._reconcile({r.name for r in ready})
 
-            if not ready:
-                self._next_for = dict.fromkeys(Orientation, None)
+            slots = self._slots_locked(collection_id)
+            eligible = self._eligible_ready_locked(ready, collection_id)
+            if not eligible:
+                for o in Orientation:
+                    slots[o] = None
                 self._save()
                 return None
 
             # If the pre-computed choice for this orientation is still valid, honour it.
-            if self._next_for.get(orientation) in ready_names:
-                return self._next_for[orientation]
+            if slots.get(orientation) in {r.name for r in eligible}:
+                return slots[orientation]
 
-            # Pre-computed choice is stale or absent — recompute all orientations.
-            self._precompute_all_locked(ready)
+            # Pre-computed choice is stale or absent — recompute this collection.
+            self._precompute_all_locked(ready, collection_id)
             self._save()
-            return self._next_for.get(orientation)
+            return slots.get(orientation)
 
-    def mark_served(self, name: str) -> None:
+    def mark_served(self, name: str, collection_id: str = ALL_COLLECTION_ID) -> None:
         """Bump rotation pointer and stats. Attributes elapsed time to the
         previously-served image. Pre-computes the next image for all orientations
         so the UI reflects the upcoming choice immediately."""
@@ -213,7 +232,10 @@ class ServeScheduler:
             ready = [r for r in self._manager.list() if r.convert_status == ConvertStatus.OK]
             ready_names = {r.name for r in ready}
             self._reconcile(ready_names)
-            self._precompute_all_locked(ready)
+            # A served image may belong to several collections. Recompute every
+            # already-used collection so the UI and the next frame poll agree.
+            for cid in list(self._next_for_by_collection):
+                self._precompute_all_locked(ready, cid)
             self._save()
 
     # ── Stats retrieval ──────────────────────────────────────────
@@ -230,12 +252,14 @@ class ServeScheduler:
         with self._lock:
             return self._last_served
 
-    def peek_next(self, orientation: Orientation) -> str | None:
+    def peek_next(
+        self, orientation: Orientation, collection_id: str = ALL_COLLECTION_ID
+    ) -> str | None:
         """Return the pre-determined next image for the given orientation without consuming it."""
         with self._lock:
-            return self._next_for.get(orientation)
+            return self._slots_locked(collection_id).get(orientation)
 
-    def set_next(self, name: str) -> None:
+    def set_next(self, name: str, collection_id: str = ALL_COLLECTION_ID) -> None:
         """Force a specific image to be served next (overrides rotation order).
 
         Raises ValueError if the image is not currently ready to serve.
@@ -245,10 +269,15 @@ class ServeScheduler:
             ready = {r.name for r in self._manager.list() if r.convert_status == ConvertStatus.OK}
             if name not in ready:
                 raise ValueError(f"Image {name!r} is not ready to serve")
-            # Override all orientation slots to the forced image (it will be
-            # filtered by orientation at serve time if a filter is active).
+            slots = self._slots_locked(collection_id)
+            if collection_id != ALL_COLLECTION_ID and not self._collections.contains(
+                collection_id, name
+            ):
+                raise ValueError(f"Image {name!r} is not in collection {collection_id!r}")
+            # Override all orientation slots to the forced image. Orientation
+            # filtering still happens when a frame asks for a particular slot.
             for o in Orientation:
-                self._next_for[o] = name
+                slots[o] = name
             self._save()
 
     # ── Screen identity (sid keyed by name + MAC) ────────────────
@@ -452,6 +481,49 @@ class ServeScheduler:
             t = self._screens.get(sid) if sid else None
             return t.screen_model if t else None
 
+    @property
+    def collection_store(self) -> CollectionStore:
+        """The metadata store used by this scheduler and the web API."""
+        return self._collections
+
+    def screen_last_served(self, name: str) -> str | None:
+        """Return the image last acknowledged by a screen, if known."""
+        with self._lock:
+            sid = self._resolve_sid_locked(name, None)
+            entry = self._screens.get(sid) if sid else None
+            return entry.last_served if entry else None
+
+    def collection_has_eligible(
+        self, collection_id: str, orientation: Orientation = Orientation.NEUTRAL
+    ) -> bool:
+        """Whether a collection has a ready image eligible for *orientation*."""
+        with self._lock:
+            ready = [r for r in self._manager.list() if r.convert_status == ConvertStatus.OK]
+            return bool(self._eligible_ready_locked(ready, collection_id, orientation=orientation))
+
+    def invalidate_collection(self, collection_id: str) -> None:
+        """Discard cached next-image choices after membership changes."""
+        with self._lock:
+            if collection_id not in self._next_for_by_collection:
+                return
+            ready = [r for r in self._manager.list() if r.convert_status == ConvertStatus.OK]
+            self._precompute_all_locked(ready, collection_id)
+            self._save()
+
+    def reset_active_collection(self, collection_id: str) -> None:
+        """Move screens away from a collection that is being deleted."""
+        with self._lock:
+            self._next_for_by_collection.pop(collection_id, None)
+            changed = False
+            for sid, config in list(self._screen_configs.items()):
+                if config.active_collection_id == collection_id:
+                    self._screen_configs[sid] = replace(
+                        config, active_collection_id=ALL_COLLECTION_ID
+                    )
+                    changed = True
+            if changed:
+                self._save()
+
     # ── OTA: per-screen update request + migration errors ─────────
 
     def set_ota_pending(self, name: str, enabled: bool, reflash: bool = False) -> None:
@@ -601,20 +673,48 @@ class ServeScheduler:
     def _atomic_write_json(self, payload: dict) -> None:
         atomic_write_json(self._db_path, payload)
 
-    def _precompute_all_locked(self, ready: list[ImageRecord]) -> None:
+    def _slots_locked(self, collection_id: str) -> dict[Orientation, str | None]:
+        if collection_id == ALL_COLLECTION_ID:
+            return self._next_for
+        return self._next_for_by_collection.setdefault(
+            collection_id, dict.fromkeys(Orientation, None)
+        )
+
+    def _eligible_ready_locked(
+        self,
+        ready: list[ImageRecord],
+        collection_id: str,
+        *,
+        orientation: Orientation | None = None,
+    ) -> list[ImageRecord]:
+        if collection_id == ALL_COLLECTION_ID:
+            eligible = ready
+        else:
+            try:
+                members = self._collections.image_names(collection_id)
+            except CollectionNotFoundError:
+                logger.warning("Unknown active collection %r; serving All Photos", collection_id)
+                eligible = ready
+            else:
+                eligible = [r for r in ready if r.name in members]
+        if orientation is not None and orientation != Orientation.NEUTRAL:
+            eligible = [r for r in eligible if r.matches_orientation_filter(orientation)]
+        return eligible
+
+    def _precompute_all_locked(
+        self, ready: list[ImageRecord], collection_id: str = ALL_COLLECTION_ID
+    ) -> None:
         """Pre-compute the next image for every orientation value.
 
         NEUTRAL = unfiltered (best across all images).
         LANDSCAPE/PORTRAIT = best among images matching that orientation filter.
         Must be called under self._lock.
         """
+        slots = self._slots_locked(collection_id)
         for orientation in Orientation:
-            if orientation == Orientation.NEUTRAL:
-                eligible = ready
-            else:
-                eligible = [r for r in ready if r.matches_orientation_filter(orientation)]
+            eligible = self._eligible_ready_locked(ready, collection_id, orientation=orientation)
             if not eligible:
-                self._next_for[orientation] = None
+                slots[orientation] = None
             else:
                 # Pick the least-shown index, then break ties randomly rather
                 # than alphabetically — new uploads keep re-tying the least-shown
@@ -622,7 +722,7 @@ class ServeScheduler:
                 # replay the same prefix first every time.
                 min_idx = min(self._stats[r.name].show_index for r in eligible)
                 tied = [r.name for r in eligible if self._stats[r.name].show_index == min_idx]
-                self._next_for[orientation] = random.choice(tied)  # noqa: S311 — rotation fairness, not crypto
+                slots[orientation] = random.choice(tied)  # noqa: S311 — rotation fairness, not crypto
 
     def _reconcile(self, ready_names: set[str]) -> None:
         # Drop orphans.
@@ -707,6 +807,18 @@ class ServeScheduler:
             old_next = data.get("next_image")
             if isinstance(old_next, str):
                 self._next_for[Orientation.NEUTRAL] = old_next
+        scoped_next = data.get("next_for_by_collection")
+        if isinstance(scoped_next, dict):
+            for collection_id, slots_raw in scoped_next.items():
+                if not isinstance(collection_id, str) or collection_id == ALL_COLLECTION_ID:
+                    continue
+                if not isinstance(slots_raw, dict):
+                    continue
+                slots = dict.fromkeys(Orientation, None)
+                for orientation in Orientation:
+                    value = slots_raw.get(orientation.value)
+                    slots[orientation] = value if isinstance(value, str) else None
+                self._next_for_by_collection[collection_id] = slots
 
     def _rebuild_indexes_locked(self) -> None:
         """Rebuild name->sid and mac->sid from the loaded records, and set the
@@ -789,6 +901,11 @@ class ServeScheduler:
             "schema": 2,
             "sid_seq": self._sid_seq,
             "next_for": {o.value: self._next_for.get(o) for o in Orientation},
+            "next_for_by_collection": {
+                collection_id: {o.value: slots.get(o) for o in Orientation}
+                for collection_id, slots in self._next_for_by_collection.items()
+                if collection_id != ALL_COLLECTION_ID
+            },
             "last_served": (
                 {"name": self._last_served[0], "served_at": self._last_served[1]}
                 if self._last_served

--- a/python/hokku/webserver/templates/index.html
+++ b/python/hokku/webserver/templates/index.html
@@ -945,6 +945,7 @@
   <div style="display:flex;align-items:center;gap:18px;flex-wrap:wrap;padding-bottom:14px;margin-bottom:14px;border-bottom:1px solid var(--bamboo-soft);">
     <div class="stat">Images: <strong id="stat-pool-size">0</strong></div>
     <div class="stat">Last served: <strong id="stat-last-served">-</strong></div>
+    <div class="stat">Serving collection: <strong id="stat-serving-collection">No connected frame</strong></div>
     <div id="processing-indicator" class="processing-indicator idle">Idle</div>
   </div>
 
@@ -3598,8 +3599,26 @@ async function deleteAllFailed(failed) {
 let lastUploadFiles = [];
 let lastServeData = {};
 let lastCollections = [];
-let currentCollectionFilter = 'all';
+const COLLECTION_FILTER_STORAGE_KEY = 'hokku.collection-filter';
 let lastNextImages = {};
+
+function readStoredCollectionFilter() {
+  try {
+    return window.localStorage.getItem(COLLECTION_FILTER_STORAGE_KEY) || 'all';
+  } catch (_) {
+    return 'all';
+  }
+}
+
+function storeCollectionFilter(id) {
+  try {
+    window.localStorage.setItem(COLLECTION_FILTER_STORAGE_KEY, id);
+  } catch (_) {
+    // Private browsing and locked-down web views may reject localStorage.
+  }
+}
+
+let currentCollectionFilter = readStoredCollectionFilter();
 
 function collectionById(id) {
   return (lastCollections || []).find(c => c.id === id) || null;
@@ -3619,7 +3638,10 @@ function refreshCollectionControls() {
   const filter = document.getElementById('collection-filter');
   const bulk = document.getElementById('bulk-collection-select');
   if (filter) {
-    if (!collectionById(currentCollectionFilter)) currentCollectionFilter = 'all';
+    if (!collectionById(currentCollectionFilter)) {
+      currentCollectionFilter = 'all';
+      storeCollectionFilter(currentCollectionFilter);
+    }
     filter.innerHTML = collectionOptions(currentCollectionFilter, true);
     filter.value = currentCollectionFilter;
   }
@@ -3645,6 +3667,26 @@ function renderCollectionWarning() {
   const empty = collection && collection.id !== 'all' && collection.image_count === 0;
   warning.classList.toggle('show', Boolean(empty));
   warning.textContent = empty ? `${collection.name} is empty. The frame will keep its current image until this collection has an eligible photo.` : '';
+}
+
+function renderServingCollection(screens) {
+  const indicator = document.getElementById('stat-serving-collection');
+  if (!indicator) return;
+  const names = Object.values(screens || {})
+    .map(screen => collectionById(screen.active_collection_id || 'all'))
+    .filter(Boolean)
+    .map(collection => collection.name)
+    .filter((name, index, all) => all.indexOf(name) === index);
+  if (!names.length) {
+    indicator.textContent = 'No connected frame';
+    indicator.title = 'No frame has checked in yet.';
+  } else if (names.length === 1) {
+    indicator.textContent = names[0];
+    indicator.title = 'All connected frames are using this collection.';
+  } else {
+    indicator.textContent = 'Mixed';
+    indicator.title = `Connected frames are using: ${names.join(', ')}`;
+  }
 }
 
 function toggleCollectionManager(force) {
@@ -3703,6 +3745,7 @@ async function deleteCollection(id) {
 
 function setCollectionFilter(id) {
   currentCollectionFilter = id || 'all';
+  storeCollectionFilter(currentCollectionFilter);
   renderCollectionWarning();
   renderImageGrid(lastUploadFiles, lastServeData, lastNextImages);
 }
@@ -4507,12 +4550,13 @@ async function refreshStatus() {
       proc.textContent = 'Idle';
     }
 
-    // Screens
+    // Screens and collection state
     lastCollections = data.collections || [];
-    refreshCollectionControls();
     lastScreens = data.screens || {};
+    renderServingCollection(lastScreens);
+    refreshCollectionControls();
     lastBundledFirmwareVersions = data.bundled_firmware_versions || {};
-    renderScreens(data.screens, lastBundledFirmwareVersions);
+    renderScreens(lastScreens, lastBundledFirmwareVersions);
 
     // Memory budget: detected system memory + the derived decode budget / workers.
     const memInfoEl = document.getElementById('memory-budget-info');

--- a/python/hokku/webserver/templates/index.html
+++ b/python/hokku/webserver/templates/index.html
@@ -604,6 +604,37 @@
     cursor: default; user-select: none;
   }
 
+  /* ── Collections ───────────────────────────────────────────── */
+  .collection-toolbar {
+    display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+    padding: 10px 0 14px; margin-bottom: 14px;
+    border-bottom: 1px solid var(--bamboo-soft);
+  }
+  .collection-toolbar label { color: var(--stone); font-size: 0.9em; font-weight: 600; }
+  .collection-toolbar select { min-width: 170px; }
+  .collection-warning {
+    display: none; margin: 0 0 14px; padding: 9px 12px;
+    color: var(--sumi); background: rgba(201, 150, 43, 0.11);
+    border: 1px solid var(--persimmon); border-radius: 6px; font-size: 0.88em;
+  }
+  .collection-warning.show { display: block; }
+  .collection-manager {
+    display: none; margin: 0 0 16px; padding: 14px 16px;
+    background: rgba(241, 232, 213, 0.52); border: 1px solid var(--bamboo);
+    border-radius: 8px;
+  }
+  .collection-manager.open { display: block; }
+  .collection-manager-header { display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:8px; }
+  .collection-manager-header h3 { margin:0; }
+  .collection-row { display:flex; align-items:center; justify-content:space-between; gap:10px; padding:8px 0; border-top:1px solid var(--bamboo-soft); font-size:0.9em; }
+  .collection-row:first-child { border-top:none; }
+  .collection-row .collection-meta { color:var(--stone); font-size:0.86em; }
+  .collection-row .collection-actions { display:flex; gap:6px; flex-shrink:0; }
+  .bulk-image-actions { display:none; align-items:center; gap:8px; flex-wrap:wrap; padding:9px 0; margin-bottom:10px; border-bottom:1px solid var(--bamboo-soft); }
+  .bulk-image-actions.show { display:flex; }
+  .image-select { position:absolute; top:10px; left:10px; z-index:4; width:22px; height:22px; accent-color:var(--indigo); }
+  .image-card.filtered-out { display:none; }
+
   /* ── Confirmation modal ───────────────────────────────────── */
   .modal-backdrop {
     position: fixed; inset: 0;
@@ -881,6 +912,34 @@
     <div class="stat">Images: <strong id="stat-pool-size">0</strong></div>
     <div class="stat">Last served: <strong id="stat-last-served">-</strong></div>
     <div id="processing-indicator" class="processing-indicator idle">Idle</div>
+  </div>
+
+  <div class="collection-toolbar">
+    <label for="collection-filter">Collection:</label>
+    <select id="collection-filter" onchange="setCollectionFilter(this.value)">
+      <option value="all">All Photos</option>
+    </select>
+    <button type="button" class="btn btn-secondary btn-small" onclick="toggleCollectionManager()">Manage collections</button>
+  </div>
+  <div id="collection-empty-warning" class="collection-warning"></div>
+  <div id="collection-manager" class="collection-manager">
+    <div class="collection-manager-header">
+      <h3>Collections</h3>
+      <button type="button" class="btn btn-secondary btn-small" onclick="toggleCollectionManager(false)">Close</button>
+    </div>
+    <div class="config-row" style="margin:0 0 10px;">
+      <input type="text" id="new-collection-name" placeholder="New collection name" maxlength="120" style="flex:1;min-width:160px;">
+      <input type="text" id="new-collection-description" placeholder="Description (optional)" maxlength="500" style="flex:2;min-width:180px;">
+      <button type="button" class="btn btn-primary btn-small" onclick="createCollection()">Create</button>
+    </div>
+    <div id="collection-list"></div>
+  </div>
+  <div id="bulk-image-actions" class="bulk-image-actions">
+    <strong><span id="selected-image-count">0</span> selected</strong>
+    <select id="bulk-collection-select"><option value="">Choose collection…</option></select>
+    <button type="button" class="btn btn-secondary btn-small" onclick="addSelectedToCollection()">Add to collection</button>
+    <button type="button" class="btn btn-secondary btn-small" onclick="removeSelectedFromCollection()">Remove from collection</button>
+    <button type="button" class="btn btn-secondary btn-small" onclick="clearImageSelection()">Clear</button>
   </div>
 
   <div class="upload-progress" id="upload-progress"></div>
@@ -3035,7 +3094,7 @@ function renderScreens(screens, bundledFirmwareVersions) {
     html += '</ul></div>';
   }
 
-  html += '<table class="screens-table"><tr><th>Name</th><th>Model</th><th>IP</th><th>Battery</th><th>Last Seen</th><th>Next Update</th><th>Last Image</th><th></th></tr>';
+  html += '<table class="screens-table"><tr><th>Name</th><th>Collection</th><th>Model</th><th>IP</th><th>Battery</th><th>Last Seen</th><th>Next Update</th><th>Last Image</th><th></th></tr>';
   names.forEach(name => {
     const s = screens[name];
     const late = overdueMinutes(s);
@@ -3057,8 +3116,12 @@ function renderScreens(screens, bundledFirmwareVersions) {
     const modelCell = s.screen_model
       ? `<span style="font-family:var(--font-mono);font-size:0.85em">${escapeHtml(s.screen_model)}</span>`
       : '<span style="color:var(--bamboo)">—</span>';
+    const collectionId = s.active_collection_id || 'all';
+    const collectionCell = `<select class="screen-collection-select" aria-label="Active collection for ${escapeHtml(name)}" onchange="setScreenCollection('${safeName}', this.value)">${collectionOptions(collectionId, true)}</select>` +
+      (s.active_collection_empty ? '<div class="collection-meta">Empty, keeping current image</div>' : '');
     html += `<tr${rowClass}>
       <td>${name}${nameBadges}</td>
+      <td>${collectionCell}</td>
       <td>${modelCell}</td>
       <td>${s.ip || '-'}</td>
       <td>${formatBattery(s)}</td>
@@ -3124,6 +3187,28 @@ async function setScreenFilterByOrientation(name, value) {
     if (lastScreens[name]) lastScreens[name].filter_by_orientation = value;
   } catch (e) {
     alert('Failed to set orientation filter: ' + e.message);
+    renderScreens(lastScreens, lastBundledFirmwareVersions);
+  }
+}
+
+async function setScreenCollection(name, value) {
+  try {
+    const r = await fetch(`/hokku/api/screens/${encodeURIComponent(name)}/collection`, {
+      method: 'PATCH',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({collection_id: value}),
+    });
+    const body = await r.json();
+    if (!r.ok) throw new Error(body.error || `HTTP ${r.status}`);
+    if (lastScreens[name]) {
+      lastScreens[name].active_collection_id = value;
+      lastScreens[name].active_collection = body.collection;
+      lastScreens[name].active_collection_empty = body.empty === true;
+    }
+    showToast(`${name} will use ${body.collection.name} on its next refresh.`);
+    renderScreens(lastScreens, lastBundledFirmwareVersions);
+  } catch (e) {
+    alert('Failed to set collection: ' + e.message);
     renderScreens(lastScreens, lastBundledFirmwareVersions);
   }
 }
@@ -3228,6 +3313,7 @@ function showScreenConfig(name) {
   const orientLandscape = s.orientation === 'landscape' ? 'selected' : '';
   const orientPortrait  = s.orientation === 'portrait'  ? 'selected' : '';
   const filterChecked   = s.filter_by_orientation ? 'checked' : '';
+  const activeCollection = s.active_collection_id || 'all';
 
   let body = `<div class="config-row">
       <label>Orientation</label>
@@ -3239,7 +3325,14 @@ function showScreenConfig(name) {
     <div class="config-row">
       <label>Match orientation</label>
       <input type="checkbox" ${filterChecked} onchange="setScreenFilterByOrientation('${safeName}', this.checked)">
+    </div>
+    <div class="config-row">
+      <label>Active collection</label>
+      <select onchange="setScreenCollection('${safeName}', this.value)">${collectionOptions(activeCollection, true)}</select>
     </div>`;
+  if (s.active_collection_empty) {
+    body += `<div class="collection-warning show">${escapeHtml((s.active_collection && s.active_collection.name) || 'This collection')} is empty. The frame will keep its current image until an eligible photo is added.</div>`;
+  }
 
   const urlOverride = s.server_url_override || '';
   const thisServerUrl = document.getElementById('flash-url')?.value || '';
@@ -3464,6 +3557,147 @@ async function deleteAllFailed(failed) {
 // Keep the last upload+serve snapshot so Details can read it without a round-trip.
 let lastUploadFiles = [];
 let lastServeData = {};
+let lastCollections = [];
+let currentCollectionFilter = 'all';
+let lastNextImages = {};
+
+function collectionById(id) {
+  return (lastCollections || []).find(c => c.id === id) || null;
+}
+
+function collectionOptions(selectedId, includeAll = true) {
+  const all = includeAll ? '<option value="all"' + (selectedId === 'all' ? ' selected' : '') + '>All Photos</option>' : '';
+  const rest = (lastCollections || []).filter(c => c.id !== 'all').map(c =>
+    `<option value="${escapeHtml(c.id)}"${c.id === selectedId ? ' selected' : ''}>${escapeHtml(c.name)} (${c.image_count})</option>`
+  ).join('');
+  return all + rest;
+}
+
+function refreshCollectionControls() {
+  const filter = document.getElementById('collection-filter');
+  const bulk = document.getElementById('bulk-collection-select');
+  if (filter) {
+    if (!collectionById(currentCollectionFilter)) currentCollectionFilter = 'all';
+    filter.innerHTML = collectionOptions(currentCollectionFilter, true);
+    filter.value = currentCollectionFilter;
+  }
+  if (bulk) bulk.innerHTML = '<option value="">Choose collection…</option>' + collectionOptions('', false);
+  renderCollectionManager();
+  renderCollectionWarning();
+}
+
+function renderCollectionManager() {
+  const list = document.getElementById('collection-list');
+  if (!list) return;
+  list.innerHTML = (lastCollections || []).map(c => {
+    const actions = c.id === 'all' ? '<span class="collection-meta">Built in</span>' :
+      `<div class="collection-actions"><button type="button" class="btn btn-secondary btn-small" onclick="renameCollection('${escapeHtml(c.id)}')">Rename</button><button type="button" class="btn btn-secondary btn-small" style="color:var(--vermilion)" onclick="deleteCollection('${escapeHtml(c.id)}')">Delete</button></div>`;
+    return `<div class="collection-row"><div><strong>${escapeHtml(c.name)}</strong><div class="collection-meta">${c.image_count} image${c.image_count === 1 ? '' : 's'}${c.description ? ' · ' + escapeHtml(c.description) : ''}</div></div>${actions}</div>`;
+  }).join('');
+}
+
+function renderCollectionWarning() {
+  const warning = document.getElementById('collection-empty-warning');
+  if (!warning) return;
+  const collection = collectionById(currentCollectionFilter);
+  const empty = collection && collection.id !== 'all' && collection.image_count === 0;
+  warning.classList.toggle('show', Boolean(empty));
+  warning.textContent = empty ? `${collection.name} is empty. The frame will keep its current image until this collection has an eligible photo.` : '';
+}
+
+function toggleCollectionManager(force) {
+  const manager = document.getElementById('collection-manager');
+  if (!manager) return;
+  const open = force == null ? !manager.classList.contains('open') : Boolean(force);
+  manager.classList.toggle('open', open);
+}
+
+async function createCollection() {
+  const nameEl = document.getElementById('new-collection-name');
+  const descEl = document.getElementById('new-collection-description');
+  const name = nameEl.value.trim();
+  if (!name) { showToast('Enter a collection name first.'); return; }
+  try {
+    const r = await fetch('/hokku/api/collections', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({name, description: descEl.value.trim()})});
+    const body = await r.json();
+    if (!r.ok) throw new Error(body.error || `HTTP ${r.status}`);
+    nameEl.value = ''; descEl.value = '';
+    showToast(`Created ${body.name}.`);
+    await refreshStatus();
+    toggleCollectionManager(true);
+  } catch (e) { showToast('Could not create collection: ' + e.message); }
+}
+
+async function renameCollection(id) {
+  const collection = collectionById(id);
+  if (!collection) return;
+  const name = window.prompt('New collection name', collection.name);
+  if (name == null || !name.trim()) return;
+  try {
+    const r = await fetch(`/hokku/api/collections/${encodeURIComponent(id)}`, {method: 'PATCH', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({name: name.trim()})});
+    const body = await r.json();
+    if (!r.ok) throw new Error(body.error || `HTTP ${r.status}`);
+    showToast(`Renamed to ${body.name}.`);
+    await refreshStatus();
+    toggleCollectionManager(true);
+  } catch (e) { showToast('Could not rename collection: ' + e.message); }
+}
+
+async function deleteCollection(id) {
+  const collection = collectionById(id);
+  if (!collection) return;
+  const ok = await showConfirm({title: 'Delete collection?', message: `Delete “${collection.name}”? The photos will stay in Hokku.`, okLabel: 'Delete'});
+  if (!ok) return;
+  try {
+    const r = await fetch(`/hokku/api/collections/${encodeURIComponent(id)}`, {method: 'DELETE'});
+    const body = await r.json();
+    if (!r.ok) throw new Error(body.error || `HTTP ${r.status}`);
+    if (currentCollectionFilter === id) currentCollectionFilter = 'all';
+    showToast('Collection deleted. Photos were kept.');
+    await refreshStatus();
+    toggleCollectionManager(true);
+  } catch (e) { showToast('Could not delete collection: ' + e.message); }
+}
+
+function setCollectionFilter(id) {
+  currentCollectionFilter = id || 'all';
+  renderCollectionWarning();
+  renderImageGrid(lastUploadFiles, lastServeData, lastNextImages);
+}
+
+function selectedImageNames() {
+  return Array.from(document.querySelectorAll('.image-select:checked')).map(el => el.dataset.name);
+}
+
+function updateSelectionActions() {
+  const names = selectedImageNames();
+  const actions = document.getElementById('bulk-image-actions');
+  const count = document.getElementById('selected-image-count');
+  if (count) count.textContent = names.length;
+  if (actions) actions.classList.toggle('show', names.length > 0);
+}
+
+function clearImageSelection() {
+  document.querySelectorAll('.image-select:checked').forEach(el => { el.checked = false; });
+  updateSelectionActions();
+}
+
+async function changeSelectedCollection(method) {
+  const names = selectedImageNames();
+  const collectionId = document.getElementById('bulk-collection-select').value;
+  if (!names.length || !collectionId) { showToast('Select photos and a collection first.'); return; }
+  try {
+    const r = await fetch(`/hokku/api/collections/${encodeURIComponent(collectionId)}/images`, {method, headers: {'Content-Type': 'application/json'}, body: JSON.stringify({images: names})});
+    const body = await r.json();
+    if (!r.ok) throw new Error(body.error || `HTTP ${r.status}`);
+    clearImageSelection();
+    showToast(method === 'POST' ? 'Photos added to collection.' : 'Photos removed from collection.');
+    await refreshStatus();
+  } catch (e) { showToast('Collection update failed: ' + e.message); }
+}
+
+function addSelectedToCollection() { return changeSelectedCollection('POST'); }
+function removeSelectedFromCollection() { return changeSelectedCollection('DELETE'); }
 
 // A small chip on the card saying which pipeline converted this picture. Only
 // shown when it isn't the plain default, so an ordinary library stays quiet.
@@ -3480,11 +3714,13 @@ function pipelineChip(entry) {
 function renderImageGrid(uploadFiles, serveData, nextImages) {
   lastUploadFiles = uploadFiles;
   lastServeData   = serveData;
+  lastNextImages  = nextImages || {};
   const grid = document.getElementById('image-grid');
   grid.innerHTML = '';
   uploadFiles.forEach(entry => {
     // Failed images are shown only in the "Failed conversions" list, not the grid.
     if (entry.status === 'failed') return;
+    if (currentCollectionFilter !== 'all' && !(entry.collection_ids || []).includes(currentCollectionFilter)) return;
     const fname    = entry.name;
     const dithered = entry.dithered;
     const imgs = nextImages || {};
@@ -3508,6 +3744,7 @@ function renderImageGrid(uploadFiles, serveData, nextImages) {
       ? nextLabels.map(l => `<span class="next-badge">${escapeHtml(l)}</span>`).join(' ')
       : '<button class="btn btn-secondary btn-small shownext-btn" data-name="">Show Next</button>';
     card.innerHTML = `
+      <input type="checkbox" class="image-select" data-name="" aria-label="Select ${escapeHtml(fname)}">
       <button class="delete-btn" data-name="" title="Delete this image">&#x1F5D1;</button>
       ${pendingBadge}
       ${thumbHtml}
@@ -3533,8 +3770,12 @@ function renderImageGrid(uploadFiles, serveData, nextImages) {
       snBtn.dataset.name = fname;
       snBtn.addEventListener('click', () => showNext(fname));
     }
+    const select = card.querySelector('.image-select');
+    select.dataset.name = fname;
+    select.addEventListener('change', updateSelectionActions);
     grid.appendChild(card);
   });
+  updateSelectionActions();
 }
 
 function showImageDetails(fname) {
@@ -4170,6 +4411,8 @@ async function refreshStatus() {
     }
 
     // Screens
+    lastCollections = data.collections || [];
+    refreshCollectionControls();
     lastScreens = data.screens || {};
     lastBundledFirmwareVersions = data.bundled_firmware_versions || {};
     renderScreens(data.screens, lastBundledFirmwareVersions);

--- a/python/hokku/webserver/templates/index.html
+++ b/python/hokku/webserver/templates/index.html
@@ -611,7 +611,15 @@
     border-bottom: 1px solid var(--bamboo-soft);
   }
   .collection-toolbar label { color: var(--stone); font-size: 0.9em; font-weight: 600; }
-  .collection-toolbar select { min-width: 170px; }
+  .collection-toolbar select {
+    min-width: 240px; min-height: 38px; padding: 6px 10px;
+    border: 1px solid var(--bamboo); border-radius: 6px;
+    font-size: 0.9em; background: var(--paper-card-solid);
+    color: var(--sumi); font-family: var(--font-sans);
+  }
+  .collection-toolbar select:focus {
+    outline: none; border-color: var(--indigo); background: #fff;
+  }
   .collection-warning {
     display: none; margin: 0 0 14px; padding: 9px 12px;
     color: var(--sumi); background: rgba(201, 150, 43, 0.11);
@@ -943,7 +951,7 @@
   <div class="collection-toolbar">
     <label for="collection-filter">Collection:</label>
     <select id="collection-filter" onchange="setCollectionFilter(this.value)">
-      <option value="all">All Photos</option>
+      <option value="all">All Photos (0)</option>
     </select>
     <button type="button" class="btn btn-secondary btn-small" onclick="toggleCollectionManager()">Manage collections</button>
   </div>
@@ -3598,7 +3606,9 @@ function collectionById(id) {
 }
 
 function collectionOptions(selectedId, includeAll = true) {
-  const all = includeAll ? '<option value="all"' + (selectedId === 'all' ? ' selected' : '') + '>All Photos</option>' : '';
+  const allCollection = collectionById('all');
+  const allCount = allCollection ? allCollection.image_count : 0;
+  const all = includeAll ? '<option value="all"' + (selectedId === 'all' ? ' selected' : '') + `>All Photos (${allCount})</option>` : '';
   const rest = (lastCollections || []).filter(c => c.id !== 'all').map(c =>
     `<option value="${escapeHtml(c.id)}"${c.id === selectedId ? ' selected' : ''}>${escapeHtml(c.name)} (${c.image_count})</option>`
   ).join('');

--- a/python/hokku/webserver/templates/index.html
+++ b/python/hokku/webserver/templates/index.html
@@ -632,8 +632,18 @@
   .collection-row .collection-actions { display:flex; gap:6px; flex-shrink:0; }
   .bulk-image-actions { display:none; align-items:center; gap:8px; flex-wrap:wrap; padding:9px 0; margin-bottom:10px; border-bottom:1px solid var(--bamboo-soft); }
   .bulk-image-actions.show { display:flex; }
+  .bulk-image-actions select { min-width: 170px; min-height: 72px; }
   .image-select { position:absolute; top:10px; left:10px; z-index:4; width:22px; height:22px; accent-color:var(--indigo); }
   .image-card.filtered-out { display:none; }
+  .image-collection-editor { margin: 14px 0 16px; padding: 12px 14px; border: 1px solid var(--bamboo); border-radius: 8px; background: rgba(241, 232, 213, 0.35); }
+  .image-collection-editor h4 { margin: 0 0 4px; font-family: var(--font-serif); color: var(--sumi); }
+  .image-collection-editor .info { margin: 0 0 10px; }
+  .collection-checks { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 8px; }
+  .collection-check { display: flex; align-items: center; gap: 8px; min-height: 38px; padding: 6px 8px; border: 1px solid var(--bamboo-soft); border-radius: 6px; background: var(--paper-card-solid); cursor: pointer; }
+  .collection-check input { width: 20px; height: 20px; accent-color: var(--indigo); flex-shrink: 0; }
+  .image-collection-editor.is-saving { opacity: 0.6; }
+  .collection-check.is-saving { opacity: 0.55; pointer-events: none; }
+  .collection-membership-summary { margin: 0 0 10px; color: var(--stone); font-size: 0.86em; }
 
   /* ── Confirmation modal ───────────────────────────────────── */
   .modal-backdrop {
@@ -839,6 +849,22 @@
   .img-detail-modal td:first-child { color: var(--stone); width: 40%; font-weight: 500; }
   .img-detail-modal .detail-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 14px; }
 
+  @media (max-width: 600px) {
+    .page { padding: 14px 12px; }
+    .collection-toolbar { align-items: stretch; }
+    .collection-toolbar label { width: 100%; }
+    .collection-toolbar select, .collection-toolbar button { width: 100%; min-height: 42px; }
+    .collection-manager .config-row { align-items: stretch; }
+    .collection-manager .config-row input, .collection-manager .config-row button { width: 100%; min-height: 42px; }
+    .collection-row { align-items: flex-start; }
+    .collection-row .collection-actions { flex-direction: column; }
+    .bulk-image-actions { align-items: stretch; }
+    .bulk-image-actions strong, .bulk-image-actions select, .bulk-image-actions button { width: 100%; min-height: 42px; }
+    .bulk-image-actions select { min-height: 96px; }
+    .img-detail-modal { width: calc(100vw - 24px); min-width: 0; padding: 18px; }
+    .collection-checks { grid-template-columns: 1fr; }
+  }
+
   .image-card .card-body { padding: 10px 12px; }
   .image-card .card-actions {
     display: flex; gap: 6px; align-items: center;
@@ -936,9 +962,9 @@
   </div>
   <div id="bulk-image-actions" class="bulk-image-actions">
     <strong><span id="selected-image-count">0</span> selected</strong>
-    <select id="bulk-collection-select"><option value="">Choose collection…</option></select>
-    <button type="button" class="btn btn-secondary btn-small" onclick="addSelectedToCollection()">Add to collection</button>
-    <button type="button" class="btn btn-secondary btn-small" onclick="removeSelectedFromCollection()">Remove from collection</button>
+    <select id="bulk-collection-select" multiple size="3" aria-label="Collections for selected photos"><option value="">Choose collection…</option></select>
+    <button type="button" class="btn btn-secondary btn-small" onclick="addSelectedToCollection()">Add to collection(s)</button>
+    <button type="button" class="btn btn-secondary btn-small" onclick="removeSelectedFromCollection()">Remove from collection(s)</button>
     <button type="button" class="btn btn-secondary btn-small" onclick="clearImageSelection()">Clear</button>
   </div>
 
@@ -1336,6 +1362,12 @@
     </div>
     <table id="img-detail-table"></table>
     <div class="detail-actions" id="img-detail-actions"></div>
+
+    <div class="image-collection-editor">
+      <h4>Collections</h4>
+      <p class="collection-membership-summary" id="img-detail-collection-summary"></p>
+      <div class="collection-checks" id="img-detail-collections"></div>
+    </div>
 
     <!-- Per-picture conversion. Both halves are independent overrides on the
          image's record: either can be set without the other, and "Use
@@ -3684,14 +3716,17 @@ function clearImageSelection() {
 
 async function changeSelectedCollection(method) {
   const names = selectedImageNames();
-  const collectionId = document.getElementById('bulk-collection-select').value;
-  if (!names.length || !collectionId) { showToast('Select photos and a collection first.'); return; }
+  const collectionIds = Array.from(document.getElementById('bulk-collection-select').selectedOptions)
+    .map(option => option.value)
+    .filter(Boolean);
+  if (!names.length || !collectionIds.length) { showToast('Select photos and one or more collections first.'); return; }
   try {
-    const r = await fetch(`/hokku/api/collections/${encodeURIComponent(collectionId)}/images`, {method, headers: {'Content-Type': 'application/json'}, body: JSON.stringify({images: names})});
+    const r = await fetch('/hokku/api/images/collections', {method, headers: {'Content-Type': 'application/json'}, body: JSON.stringify({images: names, collection_ids: collectionIds})});
     const body = await r.json();
     if (!r.ok) throw new Error(body.error || `HTTP ${r.status}`);
     clearImageSelection();
-    showToast(method === 'POST' ? 'Photos added to collection.' : 'Photos removed from collection.');
+    document.getElementById('bulk-collection-select').selectedIndex = -1;
+    showToast(method === 'POST' ? 'Photos added to collection(s).' : 'Photos removed from collection(s).');
     await refreshStatus();
   } catch (e) { showToast('Collection update failed: ' + e.message); }
 }
@@ -3776,6 +3811,56 @@ function renderImageGrid(uploadFiles, serveData, nextImages) {
     grid.appendChild(card);
   });
   updateSelectionActions();
+}
+
+function renderImageCollectionEditor(fname, entry) {
+  const host = document.getElementById('img-detail-collections');
+  const summary = document.getElementById('img-detail-collection-summary');
+  if (!host || !summary) return;
+  const memberships = new Set(entry.collection_ids || []);
+  const collections = (lastCollections || []).filter(c => c.id !== 'all');
+  const names = collections.filter(c => memberships.has(c.id)).map(c => c.name);
+  summary.textContent = names.length ? `Member of: ${names.join(', ')}` : 'Not assigned to a collection.';
+  if (!collections.length) {
+    host.innerHTML = '<span class="info">Create a collection to organize this photo.</span>';
+    return;
+  }
+  host.innerHTML = collections.map(c => `
+    <label class="collection-check">
+      <input type="checkbox" data-collection-id="${escapeHtml(c.id)}"${memberships.has(c.id) ? ' checked' : ''}>
+      <span>${escapeHtml(c.name)}</span>
+    </label>`).join('');
+  host.querySelectorAll('input[type="checkbox"]').forEach(input => {
+    input.addEventListener('change', () => saveImageCollections(fname, host));
+  });
+}
+
+async function saveImageCollections(fname, host) {
+  const inputs = Array.from(host.querySelectorAll('input[type="checkbox"]'));
+  const collectionIds = inputs.filter(input => input.checked).map(input => input.dataset.collectionId);
+  host.classList.add('is-saving');
+  inputs.forEach(input => { input.disabled = true; });
+  try {
+    const resp = await fetch('/hokku/api/image/' + encodeURIComponent(fname) + '/collections', {
+      method: 'PATCH',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({collection_ids: collectionIds}),
+    });
+    const body = await resp.json();
+    if (!resp.ok) throw new Error(body.error || `HTTP ${resp.status}`);
+    const entry = (lastUploadFiles || []).find(item => item.name === fname);
+    if (entry) entry.collection_ids = body.collection_ids || collectionIds;
+    await refreshStatus();
+    const updated = (lastUploadFiles || []).find(item => item.name === fname);
+    if (updated) renderImageCollectionEditor(fname, updated);
+    showToast('Collections updated.');
+  } catch (e) {
+    showToast('Could not update collections: ' + e.message);
+    const entry = (lastUploadFiles || []).find(item => item.name === fname);
+    if (entry) renderImageCollectionEditor(fname, entry);
+  } finally {
+    host.classList.remove('is-saving');
+  }
 }
 
 function showImageDetails(fname) {
@@ -3866,6 +3951,8 @@ function showImageDetails(fname) {
   } else {
     actions.innerHTML = '<span style="color:#92400e;font-size:0.85em">Dithered version not ready yet</span>';
   }
+
+  renderImageCollectionEditor(fname, entry);
 
   setupImageOverrideEditor(fname, entry);
 
@@ -4542,6 +4629,8 @@ async function uploadOneFile(file, row, renderAll) {
   // not doom the batch.
   const form = new FormData();
   form.append('files', file);
+  const uploadCollectionId = currentCollectionFilter !== 'all' ? currentCollectionFilter : null;
+  if (uploadCollectionId) form.append('collection_id', uploadCollectionId);
   try {
     const resp = await fetch('/hokku/api/upload', {method: 'POST', body: form});
     if (!resp.ok) {
@@ -4556,8 +4645,14 @@ async function uploadOneFile(file, row, renderAll) {
       row.status = 'ok';
       row.message = saved === file.name ? 'Uploaded' : 'Uploaded as ' + saved;
     } else if (skipped) {
-      row.status = 'error';
-      row.message = skipped.reason;
+      if (skipped.collection_added) {
+        row.status = 'ok';
+        const collection = collectionById(uploadCollectionId);
+        row.message = `Already existed; added to ${collection ? collection.name : 'collection'}`;
+      } else {
+        row.status = 'error';
+        row.message = skipped.reason;
+      }
     } else {
       row.status = 'error';
       row.message = 'Failed';

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hokku-server"
-version = "4.0.1.dev15"
+version = "4.0.1.dev17"
 description = "Spectra 6 e-ink image server for Hokku EL133UF1 display"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hokku-server"
-version = "4.0.1.dev17"
+version = "4.0.1.dev20"
 description = "Spectra 6 e-ink image server for Hokku EL133UF1 display"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/tests/test_collection_store.py
+++ b/python/tests/test_collection_store.py
@@ -15,13 +15,33 @@ from hokku.webserver.collection_store import (
 
 
 def test_existing_install_migrates_to_all_photos_without_membership_file(tmp_path: Path):
+    (tmp_path / "collections.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "collections": [
+                    {
+                        "id": "all",
+                        "name": "All Photos",
+                        "description": "",
+                        "created_at": 1,
+                        "updated_at": 1,
+                    }
+                ],
+                "memberships": {"all": ["old-family-photo.jpg"]},
+            }
+        )
+    )
     store = CollectionStore(tmp_path)
 
     all_photos = store.get(ALL_COLLECTION_ID)
     assert all_photos.name == "All Photos"
     assert store.contains(ALL_COLLECTION_ID, "old-family-photo.jpg")
     assert store.image_names(ALL_COLLECTION_ID) == set()
-    assert (tmp_path / "collections.json").exists()
+    persisted = json.loads((tmp_path / "collections.json").read_text())
+    assert persisted["version"] == 2
+    assert persisted["collections"] == []
+    assert persisted["memberships"] == {}
 
 
 def test_collection_crud_and_membership_persist(tmp_path: Path):
@@ -61,6 +81,21 @@ def test_same_image_can_belong_to_multiple_collections(tmp_path: Path):
     store.remove_images(family.id, ["shared.jpg"])
     assert not store.contains(family.id, "shared.jpg")
     assert store.contains(favorites.id, "shared.jpg")
+
+
+def test_image_membership_replacement_persists(tmp_path: Path):
+    store = CollectionStore(tmp_path)
+    family = store.create("Family")
+    favorites = store.create("Favorites")
+
+    assert store.set_image_collections("photo.jpg", [family.id, favorites.id]) == {
+        family.id,
+        favorites.id,
+    }
+    restored = CollectionStore(tmp_path)
+    assert restored.image_collections("photo.jpg") == {family.id, favorites.id}
+    assert restored.set_image_collections("photo.jpg", [favorites.id]) == {favorites.id}
+    assert restored.image_collections("photo.jpg") == {favorites.id}
 
 
 def test_deleting_all_photos_is_protected(tmp_path: Path):
@@ -109,4 +144,5 @@ def test_malformed_root_starts_with_all_photos(tmp_path: Path):
 
     store = CollectionStore(tmp_path)
 
-    assert [collection.id for collection in store.list()] == [ALL_COLLECTION_ID]
+    assert store.list() == []
+    assert store.get(ALL_COLLECTION_ID).name == "All Photos"

--- a/python/tests/test_collection_store.py
+++ b/python/tests/test_collection_store.py
@@ -1,0 +1,112 @@
+"""Persistent collection metadata and migration coverage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hokku.webserver.collection_store import (
+    ALL_COLLECTION_ID,
+    CollectionImmutableError,
+    CollectionStore,
+)
+
+
+def test_existing_install_migrates_to_all_photos_without_membership_file(tmp_path: Path):
+    store = CollectionStore(tmp_path)
+
+    all_photos = store.get(ALL_COLLECTION_ID)
+    assert all_photos.name == "All Photos"
+    assert store.contains(ALL_COLLECTION_ID, "old-family-photo.jpg")
+    assert store.image_names(ALL_COLLECTION_ID) == set()
+    assert (tmp_path / "collections.json").exists()
+
+
+def test_collection_crud_and_membership_persist(tmp_path: Path):
+    store = CollectionStore(tmp_path)
+    collection = store.create("Family", "People we love")
+    assert collection.id != ALL_COLLECTION_ID
+    assert collection.created_at == collection.updated_at
+
+    assert store.add_images(collection.id, ["a.jpg", "b.jpg"]) == 2
+    assert store.add_images(collection.id, ["a.jpg"]) == 0
+    assert store.contains(collection.id, "a.jpg")
+    assert store.image_names(collection.id) == {"a.jpg", "b.jpg"}
+
+    renamed = store.update(collection.id, name="Family & Friends")
+    assert renamed.id == collection.id
+    assert renamed.updated_at >= collection.updated_at
+
+    restored = CollectionStore(tmp_path)
+    assert restored.get(collection.id).name == "Family & Friends"
+    assert restored.image_names(collection.id) == {"a.jpg", "b.jpg"}
+
+    assert restored.remove_images(collection.id, ["a.jpg"]) == 1
+    restored.delete(collection.id)
+    assert all(c.id != collection.id for c in restored.list())
+
+
+def test_same_image_can_belong_to_multiple_collections(tmp_path: Path):
+    store = CollectionStore(tmp_path)
+    family = store.create("Family")
+    favorites = store.create("Favorites")
+
+    store.add_images(family.id, ["shared.jpg"])
+    store.add_images(favorites.id, ["shared.jpg"])
+
+    assert store.contains(family.id, "shared.jpg")
+    assert store.contains(favorites.id, "shared.jpg")
+    store.remove_images(family.id, ["shared.jpg"])
+    assert not store.contains(family.id, "shared.jpg")
+    assert store.contains(favorites.id, "shared.jpg")
+
+
+def test_deleting_all_photos_is_protected(tmp_path: Path):
+    store = CollectionStore(tmp_path)
+    with pytest.raises(CollectionImmutableError):
+        store.delete(ALL_COLLECTION_ID)
+    with pytest.raises(CollectionImmutableError):
+        store.update(ALL_COLLECTION_ID, name="Everything")
+    with pytest.raises(CollectionImmutableError):
+        store.add_images(ALL_COLLECTION_ID, ["x.jpg"])
+
+
+def test_malformed_membership_is_ignored_but_valid_collections_survive(tmp_path: Path):
+    (tmp_path / "collections.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "collections": [
+                    {
+                        "id": "all",
+                        "name": "User renamed this",
+                        "description": "bad",
+                        "created_at": 1,
+                        "updated_at": 1,
+                    },
+                    {
+                        "id": "custom",
+                        "name": "Art",
+                        "description": "",
+                        "created_at": 1,
+                        "updated_at": 1,
+                    },
+                ],
+                "memberships": {"custom": ["a.jpg", 7], "broken": "not-a-list"},
+            }
+        )
+    )
+    store = CollectionStore(tmp_path)
+    assert store.get("custom").name == "Art"
+    assert store.image_names("custom") == {"a.jpg"}
+    assert store.get(ALL_COLLECTION_ID).name == "All Photos"
+
+
+def test_malformed_root_starts_with_all_photos(tmp_path: Path):
+    (tmp_path / "collections.json").write_text(json.dumps(["not", "a", "mapping"]))
+
+    store = CollectionStore(tmp_path)
+
+    assert [collection.id for collection in store.list()] == [ALL_COLLECTION_ID]

--- a/python/tests/test_flask_api.py
+++ b/python/tests/test_flask_api.py
@@ -236,6 +236,100 @@ def test_show_next_not_ready_returns_409(bare_client):
     assert resp.status_code == 409
 
 
+# ── /hokku/api/collections ───────────────────────────────────────────────────
+
+
+def test_collection_crud_and_image_membership(synced_client):
+    client, _, name = synced_client
+    created = client.post(
+        "/hokku/api/collections",
+        json={"name": "Family", "description": "People we love"},
+    )
+    assert created.status_code == 201
+    collection = created.get_json()
+    assert collection["name"] == "Family"
+    assert collection["image_count"] == 0
+    collection_id = collection["id"]
+
+    added = client.post(f"/hokku/api/collections/{collection_id}/images", json={"images": [name]})
+    assert added.status_code == 200
+    assert added.get_json()["images"] == [name]
+
+    listed = client.get("/hokku/api/collections").get_json()["collections"]
+    assert {entry["name"] for entry in listed} >= {"All Photos", "Family"}
+    family = next(entry for entry in listed if entry["id"] == collection_id)
+    assert family["image_count"] == 1
+
+    renamed = client.patch(f"/hokku/api/collections/{collection_id}", json={"name": "Favorites"})
+    assert renamed.status_code == 200
+    assert renamed.get_json()["name"] == "Favorites"
+
+    removed = client.delete(f"/hokku/api/collections/{collection_id}/images/{name}")
+    assert removed.status_code == 200
+    assert removed.get_json()["images"] == []
+
+    deleted = client.delete(f"/hokku/api/collections/{collection_id}")
+    assert deleted.status_code == 200
+    assert all(
+        entry["id"] != collection_id
+        for entry in client.get("/hokku/api/collections").get_json()["collections"]
+    )
+    # Collection deletion never deletes the source image.
+    assert client.get(f"/hokku/api/original/{name}").status_code == 200
+
+
+def test_all_photos_is_backward_compatible_and_image_status_has_memberships(synced_client):
+    client, _, name = synced_client
+    data = client.get("/hokku/api/status").get_json()
+    entry = next(item for item in data["upload_files"] if item["name"] == name)
+    assert "all" in entry["collection_ids"]
+    assert any(c["id"] == "all" and c["image_count"] == 1 for c in data["collections"])
+
+
+def test_screen_active_collection_persists_and_can_be_read(synced_client):
+    client, state, _ = synced_client
+    created = client.post("/hokku/api/collections", json={"name": "Family"}).get_json()
+    collection_id = created["id"]
+    set_resp = client.patch(
+        "/hokku/api/screens/hallway/collection", json={"collection_id": collection_id}
+    )
+    assert set_resp.status_code == 200
+    set_body = set_resp.get_json()
+    assert set_body["active_collection_id"] == collection_id
+    assert set_body["collection"]["id"] == collection_id
+    assert set_body["empty"] is True
+    get_resp = client.get("/hokku/api/screens/hallway/collection")
+    assert get_resp.status_code == 200
+    assert get_resp.get_json()["collection"]["id"] == collection_id
+    assert state.scheduler.get_screen_config("hallway").active_collection_id == collection_id
+
+
+def test_empty_active_collection_preserves_current_frame_image(synced_client):
+    client, state, name = synced_client
+    first = client.get(
+        "/hokku/screen/",
+        headers={"X-Screen-Name": "hallway", "X-Screen-Model": "huessen_epf1301"},
+    )
+    assert first.status_code == 200
+    before = state.scheduler.stats_for(name)
+    assert before is not None and before.total_show_count == 1
+
+    empty = client.post("/hokku/api/collections", json={"name": "Empty"}).get_json()
+    changed = client.patch(
+        "/hokku/api/screens/hallway/collection",
+        json={"collection_id": empty["id"]},
+    )
+    assert changed.status_code == 200
+    second = client.get(
+        "/hokku/screen/",
+        headers={"X-Screen-Name": "hallway", "X-Screen-Model": "huessen_epf1301"},
+    )
+    assert second.status_code == 200
+    assert second.data == first.data
+    after = state.scheduler.stats_for(name)
+    assert after is not None and after.total_show_count == 1
+
+
 # ── /hokku/api/status GET ─────────────────────────────────────────────────────
 
 

--- a/python/tests/test_flask_api.py
+++ b/python/tests/test_flask_api.py
@@ -28,6 +28,7 @@ from dataclasses import asdict
 from pathlib import Path
 
 import pytest
+from werkzeug.datastructures import MultiDict
 
 from hokku.webserver.app_config import AppConfig
 from hokku.webserver.app_state import AppState, build_manager
@@ -92,11 +93,27 @@ def synced_client(app_config: AppConfig, tmp_path: Path):
     return app.test_client(), state, src.name
 
 
-def _upload_bytes(client, data: bytes, filename: str):
+def _upload_bytes(client, data: bytes, filename: str, collection_id: str | None = None):
     """POST multipart/form-data to /hokku/api/upload."""
+    form: dict[str, object] = {"file": (io.BytesIO(data), filename)}
+    if collection_id is not None:
+        form["collection_id"] = collection_id
     return client.post(
         "/hokku/api/upload",
-        data={"file": (io.BytesIO(data), filename)},
+        data=form,
+        content_type="multipart/form-data",
+    )
+
+
+def _upload_many(client, files: list[tuple[bytes, str]], collection_id: str | None = None):
+    form: MultiDict[str, object] = MultiDict(
+        [("files", (io.BytesIO(data), filename)) for data, filename in files]
+    )
+    if collection_id is not None:
+        form.add("collection_id", collection_id)
+    return client.post(
+        "/hokku/api/upload",
+        data=form,
         content_type="multipart/form-data",
     )
 
@@ -162,6 +179,76 @@ def test_upload_duplicate_is_skipped(bare_client):
     assert "already exists" in body2["skipped"][0]["reason"]
 
 
+def test_upload_to_all_photos_has_no_collection_membership(bare_client):
+    client, state = bare_client
+    img = _TEST_IMAGES_DIR / "grayscale_linear_bar_1200x300.png"
+
+    response = _upload_bytes(client, img.read_bytes(), img.name)
+
+    assert response.status_code == 200
+    entry = next(
+        item
+        for item in client.get("/hokku/api/status").get_json()["upload_files"]
+        if item["name"] == img.name
+    )
+    assert entry["collection_ids"] == []
+    assert state.collections.list() == []
+    assert state.collections.image_collections(img.name) == set()
+
+
+def test_upload_to_collection_assigns_membership(bare_client):
+    client, _ = bare_client
+    family = client.post("/hokku/api/collections", json={"name": "Family"}).get_json()
+    img = _TEST_IMAGES_DIR / "grayscale_linear_bar_1200x300.png"
+
+    response = _upload_bytes(client, img.read_bytes(), img.name, family["id"])
+
+    assert response.status_code == 200
+    entry = next(
+        item
+        for item in client.get("/hokku/api/status").get_json()["upload_files"]
+        if item["name"] == img.name
+    )
+    assert entry["collection_ids"] == [family["id"]]
+
+
+def test_multi_upload_to_collection_assigns_every_successful_image(bare_client):
+    client, _ = bare_client
+    family = client.post("/hokku/api/collections", json={"name": "Family"}).get_json()
+    files = [
+        (_TEST_IMAGES_DIR.joinpath("grayscale_linear_bar_1200x300.png").read_bytes(), "one.png"),
+        (_TEST_IMAGES_DIR.joinpath("grayscale_linear_bar_1200x300.png").read_bytes(), "two.png"),
+    ]
+
+    response = _upload_many(client, files, family["id"])
+
+    assert response.status_code == 200
+    assert set(response.get_json()["saved"]) == {"one.png", "two.png"}
+    entries = {
+        item["name"]: item for item in client.get("/hokku/api/status").get_json()["upload_files"]
+    }
+    assert entries["one.png"]["collection_ids"] == [family["id"]]
+    assert entries["two.png"]["collection_ids"] == [family["id"]]
+
+
+def test_duplicate_upload_to_collection_adds_existing_image_without_duplication(bare_client):
+    client, _ = bare_client
+    family = client.post("/hokku/api/collections", json={"name": "Family"}).get_json()
+    img = _TEST_IMAGES_DIR / "grayscale_linear_bar_1200x300.png"
+    _upload_bytes(client, img.read_bytes(), img.name)
+
+    response = _upload_bytes(client, img.read_bytes(), img.name, family["id"])
+
+    body = response.get_json()
+    assert response.status_code == 200
+    assert body["saved"] == []
+    assert body["collection_added"] == [img.name]
+    assert client.get(f"/hokku/api/collections/{family['id']}/images").get_json()["images"] == [
+        img.name
+    ]
+    assert len(client.get("/hokku/api/status").get_json()["upload_files"]) == 1
+
+
 def test_upload_bad_extension_is_skipped(bare_client):
     client, _ = bare_client
     resp = _upload_bytes(client, b"not an image", "photo.xyz")
@@ -182,6 +269,22 @@ def test_delete_existing_image(bare_client):
     resp = client.delete(f"/hokku/api/image/{img.name}")
     assert resp.status_code == 200
     assert resp.get_json()["ok"] is True
+
+
+def test_deleting_image_removes_collection_memberships(bare_client):
+    client, _ = bare_client
+    img = _TEST_IMAGES_DIR / "grayscale_linear_bar_1200x300.png"
+    _upload_bytes(client, img.read_bytes(), img.name)
+    family = client.post("/hokku/api/collections", json={"name": "Family"}).get_json()
+    client.post(
+        f"/hokku/api/collections/{family['id']}/images",
+        json={"images": [img.name]},
+    )
+
+    response = client.delete(f"/hokku/api/image/{img.name}")
+
+    assert response.status_code == 200
+    assert client.get(f"/hokku/api/collections/{family['id']}/images").get_json()["images"] == []
 
 
 def test_delete_missing_image_returns_404(bare_client):
@@ -278,11 +381,74 @@ def test_collection_crud_and_image_membership(synced_client):
     assert client.get(f"/hokku/api/original/{name}").status_code == 200
 
 
+def test_image_collection_membership_can_be_read_and_replaced(synced_client):
+    client, _, name = synced_client
+    family = client.post("/hokku/api/collections", json={"name": "Family"}).get_json()
+    favorites = client.post("/hokku/api/collections", json={"name": "Favorites"}).get_json()
+
+    added = client.patch(
+        f"/hokku/api/image/{name}/collections",
+        json={"collection_ids": [family["id"], favorites["id"]]},
+    )
+    assert added.status_code == 200
+    assert set(added.get_json()["collection_ids"]) == {family["id"], favorites["id"]}
+
+    removed_family = client.patch(
+        f"/hokku/api/image/{name}/collections",
+        json={"collection_ids": [favorites["id"]]},
+    )
+    assert removed_family.status_code == 200
+    assert removed_family.get_json()["collection_ids"] == [favorites["id"]]
+    assert client.get(f"/hokku/api/collections/{family['id']}/images").get_json()["images"] == []
+    assert client.get(f"/hokku/api/collections/{favorites['id']}/images").get_json()["images"] == [
+        name
+    ]
+
+
+def test_bulk_collection_membership_add_and_remove(synced_client):
+    client, _, first_name = synced_client
+    second_name = "second.png"
+    source = _TEST_IMAGES_DIR / "grayscale_linear_bar_1200x300.png"
+    _upload_bytes(client, source.read_bytes(), second_name)
+    family = client.post("/hokku/api/collections", json={"name": "Family"}).get_json()
+    favorites = client.post("/hokku/api/collections", json={"name": "Favorites"}).get_json()
+
+    added = client.post(
+        "/hokku/api/images/collections",
+        json={
+            "images": [first_name, second_name],
+            "collection_ids": [family["id"], favorites["id"]],
+        },
+    )
+    assert added.status_code == 200
+    assert added.get_json()["changed"] == 4
+
+    removed = client.delete(
+        "/hokku/api/images/collections",
+        json={"images": [first_name, second_name], "collection_ids": [family["id"]]},
+    )
+    assert removed.status_code == 200
+    assert removed.get_json()["changed"] == 2
+    assert client.get(f"/hokku/api/collections/{favorites['id']}/images").get_json()["count"] == 2
+
+
+def test_upload_rejects_deleted_collection_id(bare_client):
+    client, _ = bare_client
+    family = client.post("/hokku/api/collections", json={"name": "Family"}).get_json()
+    client.delete(f"/hokku/api/collections/{family['id']}")
+    img = _TEST_IMAGES_DIR / "grayscale_linear_bar_1200x300.png"
+
+    response = _upload_bytes(client, img.read_bytes(), img.name, family["id"])
+
+    assert response.status_code == 404
+    assert client.get("/hokku/api/status").get_json()["upload_files"] == []
+
+
 def test_all_photos_is_backward_compatible_and_image_status_has_memberships(synced_client):
     client, _, name = synced_client
     data = client.get("/hokku/api/status").get_json()
     entry = next(item for item in data["upload_files"] if item["name"] == name)
-    assert "all" in entry["collection_ids"]
+    assert entry["collection_ids"] == []
     assert any(c["id"] == "all" and c["image_count"] == 1 for c in data["collections"])
 
 

--- a/python/tests/test_serve_scheduler.py
+++ b/python/tests/test_serve_scheduler.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 from pathlib import Path
 
 from hokku.webserver.app_config import AppConfig
+from hokku.webserver.collection_store import ALL_COLLECTION_ID
 from hokku.webserver.image_manager_single import SingleThreadedImageManager
 from hokku.webserver.orientation import Orientation
 from hokku.webserver.screen_config import ScreenConfig
@@ -43,6 +44,64 @@ def test_pick_next_empty(app_config: AppConfig):
     mgr = SingleThreadedImageManager(app_config)
     sched = ServeScheduler(mgr)
     assert sched.pick_next(Orientation.NEUTRAL) is None
+
+
+def test_collections_filter_rotation_without_resetting_global_stats(
+    app_config: AppConfig, make_test_image
+):
+    _mgr, sched = _setup(app_config, make_test_image, ["family.jpg", "art.jpg", "travel.jpg"])
+    family = sched.collection_store.create("Family")
+    sched.collection_store.add_images(family.id, ["family.jpg"])
+    sched.invalidate_collection(family.id)
+
+    assert sched.pick_next(Orientation.NEUTRAL, family.id) == "family.jpg"
+    sched.mark_served("family.jpg", collection_id=family.id)
+    stats = sched.stats_for("family.jpg")
+    assert stats is not None
+    assert stats.total_show_count == 1
+    assert sched.pick_next(Orientation.NEUTRAL, family.id) == "family.jpg"
+    # All Photos still sees the other images and uses the same global stats.
+    assert sched.pick_next(Orientation.NEUTRAL, ALL_COLLECTION_ID) in {
+        "art.jpg",
+        "travel.jpg",
+    }
+
+
+def test_collection_fair_rotation_only_counts_members(app_config: AppConfig, make_test_image):
+    _mgr, sched = _setup(app_config, make_test_image, ["a.jpg", "b.jpg", "outside.jpg"])
+    collection = sched.collection_store.create("Pair")
+    sched.collection_store.add_images(collection.id, ["a.jpg", "b.jpg"])
+    counts = {"a.jpg": 0, "b.jpg": 0}
+    for _ in range(8):
+        name = sched.pick_next(Orientation.NEUTRAL, collection.id)
+        assert name in counts
+        counts[name] += 1
+        sched.mark_served(name, collection.id)
+    assert counts == {"a.jpg": 4, "b.jpg": 4}
+    stats = sched.stats_for("outside.jpg")
+    assert stats is not None
+    assert stats.total_show_count == 0
+
+
+def test_empty_collection_returns_no_candidate_for_route_fallback(
+    app_config: AppConfig, make_test_image
+):
+    _, sched = _setup(app_config, make_test_image, ["a.jpg"])
+    empty = sched.collection_store.create("Empty")
+    assert sched.pick_next(Orientation.NEUTRAL, empty.id) is None
+    assert not sched.collection_has_eligible(empty.id)
+
+
+def test_active_collection_persists_per_screen(app_config: AppConfig, make_test_image):
+    mgr, sched = _setup(app_config, make_test_image, ["a.jpg"])
+    collection = sched.collection_store.create("Family")
+    sched.record_screen_call("hallway", "1.2.3.4", 300, None, None, None)
+    sched.set_screen_config("hallway", ScreenConfig(active_collection_id=collection.id))
+    sched2 = ServeScheduler(mgr)
+    assert sched2.get_screen_config("hallway").active_collection_id == collection.id
+    assert sched2.collection_store.get(collection.id).name == "Family"
+    sched2.reset_active_collection(collection.id)
+    assert sched2.get_screen_config("hallway").active_collection_id == ALL_COLLECTION_ID
 
 
 def test_pick_next_single(app_config: AppConfig, make_test_image):

--- a/python/tests/test_ui_template.py
+++ b/python/tests/test_ui_template.py
@@ -94,3 +94,9 @@ def test_no_references_to_the_retired_state_variables(rendered_ui: str):
     for name in ("bwDitherState", "faceDitherState"):
         assert name not in js
     assert "ditherStates" in js
+
+
+def test_collection_context_persists_and_serving_indicator_is_mounted(rendered_ui: str):
+    """The page exposes the frame-serving status alongside the image stats."""
+    assert 'id="stat-serving-collection"' in rendered_ui
+    assert "Serving collection:" in rendered_ui


### PR DESCRIPTION
## Summary

Add first-class photo Collections and per-frame collection selection to Hokku.

This is related to the tagging/seasonal-collection discussion in #18.

## User-visible behavior

- All existing photos remain in the default `All Photos` collection.
- Users can create, rename, and delete named collections without deleting photos.
- Images can belong to multiple collections.
- The Images view supports collection filtering, bulk selection, and adding or removing selected images from a collection.
- The Screens view shows and updates each frame's active collection.
- A collection switch is persisted and takes effect on the frame's next scheduled check-in.
- Empty collections are handled gracefully: the current displayed image is preserved and the UI reports that there are no eligible images.

## Implementation

- Adds a small metadata-backed JSON collection store with stable IDs, timestamps, descriptions, and image membership.
- Keeps image files, conversion artifacts, and existing display statistics unchanged.
- Filters the existing `ServeScheduler` candidate set rather than introducing a second scheduler.
- Keeps display history global per image while scoping next-image state to the active collection.
- Persists the active collection in the existing per-screen configuration.
- Exposes collection CRUD, membership, and per-frame selection through the existing Flask JSON API.
- Documents the API surface for future automation clients.

## Backward compatibility and migration

- Existing installations require no manual migration.
- `All Photos` is protected and represents the pre-Collections behavior.
- Existing images and display history remain valid.
- No firmware or frame-protocol changes are required.
- Normal Hokku rotation remains independent of OpenClaw or any cloud service.

## UI verification

The existing web UI was manually exercised at desktop and 390x844 phone-sized viewports. The checks covered collection creation, multi-image membership, filtering to a collection, and switching a simulated frame from All Photos to Family with persistence confirmed through the API.

## Tests

- Pristine upstream baseline (`f8876f6`): `997 passed, 2 skipped`
- Collections branch: `1010 passed, 2 skipped`
- Focused Collections tests: `127 passed`
- Ruff lint and format: clean
- Pyright: `0 errors, 0 warnings`

## Trade-offs

The implementation uses Hokku's existing JSON persistence model instead of adding a database or moving image files. This keeps the migration small and preserves the current deployment architecture. The current frame protocol has no server-side wake command, so collection changes intentionally apply on the next scheduled refresh rather than waking a sleeping frame.
